### PR TITLE
Revamp site with ethereal theme

### DIFF
--- a/about.html
+++ b/about.html
@@ -4,155 +4,141 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>About — Michael C. Barros</title>
-
+  <meta name="description" content="Scholar of religion and popular culture exploring esoteric imagination across games, film, and fiction." />
   <link rel="stylesheet" href="./style.css" />
   <style>
-    /* Page-scoped polish for About */
-    :root{ --ink:#111827; --muted:#6b7280; --ring:rgba(15,118,110,.25); }
-    .shell{max-width:1160px;margin:0 auto;padding:24px 20px 56px}
-
-    /* Hero block */
-    .about-hero{
-      display:grid; gap:18px; align-items:end; margin:8px 0 18px;
+    .about-hero {
+      display: grid;
+      gap: 2rem;
     }
-    @media (min-width:980px){
-      .about-hero{ grid-template-columns: minmax(260px, 360px) 1fr; }
+    @media (min-width: 960px) {
+      .about-hero {
+        grid-template-columns: minmax(0, 360px) minmax(0, 1fr);
+      }
     }
-    .about-title h1{
-      margin:0; font-size:clamp(2rem, 4.2vw, 3.2rem); letter-spacing:-.015em;
-      line-height:1.05;
+    .about-list {
+      display: grid;
+      gap: 1.4rem;
     }
-    .about-kicker{
-      color:var(--muted);
-      font-weight:600;
-      line-height:1.25;
-      white-space:pre-line;               /* keeps the stacked lines look */
+    @media (min-width: 880px) {
+      .about-list {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
     }
-
-    /* Summary paragraph */
-    .lede{font-size:1.05rem; line-height:1.8; color:var(--ink); margin-top:8px}
-
-    /* Quick actions */
-    .cta-row{display:flex; gap:.6rem; flex-wrap:wrap; margin:14px 0 2px}
-    .btn{display:inline-block;padding:.7rem 1.1rem;border-radius:.8rem;background:#111827;color:#fff;
-      text-decoration:none;font-weight:700;transition:transform .15s ease, box-shadow .15s ease}
-    .btn:hover{transform:translateY(-2px);box-shadow:0 8px 18px rgba(0,0,0,.12)}
-    .btn.ghost{background:transparent;color:#111827;border:2px solid #111827}
-
-    /* Section headings */
-    .section{margin:26px 0}
-    .section h2{font-size:1.6rem; margin:.2rem 0 .6rem}
-
-    /* Two-column details list */
-    .cols{display:grid; gap:14px}
-    @media(min-width:980px){ .cols{grid-template-columns:1fr 1fr} }
-    .card{background:#fff;border:1px solid rgba(0,0,0,.08);border-radius:12px;padding:16px}
-
-    .muted{color:var(--muted)}
-    .divider{height:1px;background:#e5e7eb;margin:24px 0}
-    .footer{padding:36px 0;text-align:center;color:var(--muted);font-size:.95rem}
+    ul.about-items {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+      display: grid;
+      gap: 0.55rem;
+    }
+    ul.about-items li::before {
+      content: '✧';
+      color: var(--accent);
+      margin-right: 0.55rem;
+    }
   </style>
 </head>
-<body>
+<body class="page page--about">
   <div class="shell">
-    <!-- Header -->
-    <header class="site-header">
+    <header class="site-header" aria-label="Site">
       <a class="brand" href="./index.html">Michael C. Barros</a>
-      <nav class="nav" aria-label="Main">
-        <a href="./about.html" aria-current="page">About</a>
-        <a href="./books.html">Books</a>
-        <a id="nav-blog" href="#" target="_blank" rel="noopener">Blog</a>
-        <a href="./projects.html">Projects</a>
-        <a id="nav-research" href="#" target="_blank" rel="noopener">Research</a>
-        <a href="./contact.html">Contact</a>
+      <nav class="nav" aria-label="Primary">
+        <a class="nav__link" href="./about.html" aria-current="page">About</a>
+        <a class="nav__link" href="./books.html">Books</a>
+        <a class="nav__link" id="nav-blog" href="#" target="_blank" rel="noopener">Blog</a>
+        <a class="nav__link" href="./projects.html">Projects</a>
+        <a class="nav__link" id="nav-research" href="#" target="_blank" rel="noopener">Research</a>
+        <a class="nav__link" href="./contact.html">Contact</a>
       </nav>
     </header>
 
-    <!-- Hero -->
-    <section class="about-hero">
-      <div class="about-title">
-        <h1>About</h1>
-        <div class="about-kicker">Scholar of
-religion &amp;
-popular
-culture</div>
-      </div>
-
-      <div>
-        <p class="lede">
-          Michael C. Barros studies how games, film, and speculative fiction become sites of religious
-          experience, symbolic imagination, and encounters with the sacred. His work draws on theology,
-          cultural history, and media analysis.
-        </p>
-
+    <main>
+      <section class="page-header">
+        <span class="eyebrow">About</span>
+        <h1 class="page-title">Michael C. Barros</h1>
+        <p class="page-kicker">Scholar of religion and popular culture tracing how myth, ritual, and sacred imagination constellate within contemporary media.</p>
         <div class="cta-row" role="group" aria-label="Primary actions">
           <a class="btn" href="./books.html">Books</a>
           <a class="btn ghost" href="./projects.html">Projects</a>
           <a class="btn ghost" href="./contact.html">Curriculum Vitae</a>
         </div>
-      </div>
-    </section>
+      </section>
 
-    <div class="divider" role="presentation"></div>
+      <section class="section-card">
+        <div class="about-hero">
+          <div class="feature-media feature-media--avatar" role="img" aria-label="Abstract portrait of Michael C. Barros"></div>
+          <div class="feature-body">
+            <h2>Mythopoesis in the everyday</h2>
+            <p>Michael C. Barros studies how games, film, and speculative fiction become sites of religious experience and esoteric imagination. His work draws on theology, cultural history, and media analysis to surface the hidden architectures of meaning.</p>
+            <p>He develops frameworks that help players, readers, and viewers recognize the sacred textures embedded in contemporary storytelling—offering tools for both scholarship and practice.</p>
+          </div>
+        </div>
+      </section>
 
-    <!-- Affiliations & Focus -->
-    <section class="section">
-      <h2>Affiliations &amp; Focus</h2>
-      <div class="cols">
-        <div class="card">
-          <h3 style="margin:.1rem 0 .35rem">Areas</h3>
-          <ul class="muted" style="margin:.4rem 0 0; padding-left:1.1rem">
-            <li>Religion &amp; popular culture</li>
-            <li>Myth, ritual, and symbolic imagination</li>
-            <li>Games &amp; interactive media</li>
-            <li>Film and speculative fiction</li>
-          </ul>
-        </div>
-        <div class="card">
-          <h3 style="margin:.1rem 0 .35rem">Methods</h3>
-          <ul class="muted" style="margin:.4rem 0 0; padding-left:1.1rem">
-            <li>Theology &amp; religious studies</li>
-            <li>Media analysis &amp; cultural history</li>
-            <li>Reception &amp; adaptation studies</li>
-          </ul>
-        </div>
-      </div>
-    </section>
+      <div class="divider" role="presentation"></div>
 
-    <!-- Recent & Links -->
-    <section class="section">
-      <h2>Selected Links</h2>
-      <div class="cols">
-        <div class="card">
-          <h3 style="margin:.1rem 0 .35rem">Research profile</h3>
-          <p class="muted" style="margin:.35rem 0 .6rem">
-            External publications, preprints, and works-in-progress.
-          </p>
-          <a class="btn" id="about-research" href="#" target="_blank" rel="noopener">Open ResearchGate</a>
+      <section>
+        <div class="section-heading">
+          <h2>Focus &amp; affiliations</h2>
         </div>
-        <div class="card">
-          <h3 style="margin:.1rem 0 .35rem">Substack</h3>
-          <p class="muted" style="margin:.35rem 0 .6rem">
-            Short-form writing, notes, and ongoing conversations.
-          </p>
-          <a class="btn ghost" id="about-blog" href="#" target="_blank" rel="noopener">Visit Substack</a>
+        <div class="about-list">
+          <article class="info-card">
+            <h3>Areas of inquiry</h3>
+            <ul class="about-items">
+              <li>Religion &amp; popular culture</li>
+              <li>Myth, ritual, and symbolic imagination</li>
+              <li>Games &amp; interactive media</li>
+              <li>Film and speculative fiction</li>
+            </ul>
+          </article>
+          <article class="info-card">
+            <h3>Approaches</h3>
+            <ul class="about-items">
+              <li>Theology &amp; religious studies</li>
+              <li>Media analysis &amp; cultural history</li>
+              <li>Reception &amp; adaptation studies</li>
+              <li>Ethnography of fandom &amp; play</li>
+            </ul>
+          </article>
         </div>
-      </div>
-    </section>
+      </section>
 
-    <footer class="footer">© <span id="year"></span> Michael C. Barros</footer>
+      <div class="divider" role="presentation"></div>
+
+      <section>
+        <div class="section-heading">
+          <h2>Connect</h2>
+        </div>
+        <div class="detail-grid two-col">
+          <article class="info-card">
+            <h3>Research profiles</h3>
+            <p>External publications, preprints, and works-in-progress.</p>
+            <a class="btn" id="about-research" href="#" target="_blank" rel="noopener">Open Research</a>
+          </article>
+          <article class="info-card">
+            <h3>Substack</h3>
+            <p>Short-form writing, field notes, and ongoing conversations.</p>
+            <a class="btn ghost" id="about-blog" href="#" target="_blank" rel="noopener">Visit Substack</a>
+          </article>
+        </div>
+      </section>
+    </main>
+
+    <footer>© <span id="year"></span> Michael C. Barros</footer>
   </div>
 
-  <!-- Shared data + nav injection -->
   <script defer src="./js/data/data.js"></script>
   <script defer src="./js/nav.js"></script>
   <script>
-    // Page-local hookups
     window.addEventListener('DOMContentLoaded', () => {
       const links = (window.SITE_DATA && window.SITE_DATA.links) || window.LINKS || {};
-      document.getElementById('about-research').href = links.research || 'https://www.researchgate.net/';
-      document.getElementById('about-blog').href = links.blog || 'https://mythonoesis.substack.com/';
-      document.getElementById('year').textContent = new Date().getFullYear();
+      const research = document.getElementById('about-research');
+      if (research) research.href = links.research || 'https://www.researchgate.net/';
+      const blog = document.getElementById('about-blog');
+      if (blog) blog.href = links.blog || 'https://mythonoesis.substack.com/';
+      const year = document.getElementById('year');
+      if (year) year.textContent = new Date().getFullYear();
     });
   </script>
 </body>

--- a/books.html
+++ b/books.html
@@ -4,180 +4,195 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Books — Michael C. Barros</title>
-
+  <meta name="description" content="Books and forthcoming work on religion, myth, and popular culture by Michael C. Barros." />
   <link rel="stylesheet" href="./style.css" />
   <style>
-    :root{ --ink:#111827; --muted:#6b7280; --ring:rgba(15,118,110,.25); }
-    .shell{max-width:1100px;margin:0 auto;padding:20px 20px 48px}
-    .site-header{display:flex;align-items:center;justify-content:space-between;padding:10px 0}
-    .brand{font-weight:700;text-decoration:none;color:var(--ink)}
-    .nav{display:flex;gap:18px;flex-wrap:wrap}
-    .nav a{color:var(--ink);text-decoration:none}
-    .nav a:hover{text-decoration:underline}
-
-    .page-title{font-size:2.25rem;margin:0 0 .35rem}
-    .muted{color:var(--muted)}
-    .divider{height:1px;background:#e5e7eb;margin:24px 0}
-
-    .book-hero{display:grid;gap:22px;align-items:start}
-    @media(min-width:980px){ .book-hero{grid-template-columns: 280px 1fr} }
-    .book-cover{width:100%;height:auto;border-radius:12px;box-shadow:0 10px 28px rgba(0,0,0,.12)}
-    .book-head h2{margin:.1rem 0 .35rem;font-size:1.75rem}
-    .status-pill{display:inline-block;font-size:.75rem;border:1px solid #e5e7eb;border-radius:999px;padding:.22rem .6rem;margin-right:.4rem}
-    .cta-row{display:flex;gap:.6rem;flex-wrap:wrap;margin-top:.6rem}
-    .btn{display:inline-block;padding:.7rem 1.1rem;border-radius:.7rem;background:#111827;color:#fff;font-weight:700;text-decoration:none}
-    .btn:hover{filter:brightness(1.08)}
-    .btn.ghost{background:transparent;color:#111827;border:2px solid #111827}
-
-    .desc p{margin:.65rem 0;line-height:1.7}
-    .blurbs{display:grid;gap:16px;margin-top:18px}
-    @media(min-width:980px){ .blurbs{grid-template-columns: repeat(2,1fr)} }
-    .blurb{background:#fff;border:1px solid rgba(160,125,59,.25);border-radius:12px;padding:16px;box-shadow:0 6px 18px rgba(0,0,0,.06)}
-    .blurb blockquote{margin:0 0 .6rem;font-size:1.05rem;line-height:1.6}
-    .blurb small{color:var(--muted)}
-
-    .more-wrap{margin-top:28px}
-    .grid{display:grid;gap:16px}
-    @media(min-width:900px){ .grid.cols-3{grid-template-columns:repeat(3,1fr)} }
-    .card{background:#fff;border:1px solid rgba(160,125,59,.25);border-radius:12px;padding:16px;transition:.2s}
-    .card:hover{border-color:rgba(160,125,59,.5);box-shadow:0 10px 26px rgba(0,0,0,.08);transform:translateY(-2px)}
+    .book-hero {
+      display: grid;
+      gap: 2rem;
+    }
+    @media (min-width: 980px) {
+      .book-hero {
+        grid-template-columns: minmax(0, 320px) minmax(0, 1fr);
+      }
+    }
+    .status-pill {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.35rem;
+      padding: 0.3rem 0.85rem;
+      border-radius: 999px;
+      border: 1px solid rgba(192, 132, 252, 0.4);
+      background: rgba(192, 132, 252, 0.18);
+      color: #f5f2ff;
+      font-size: 0.75rem;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+    }
+    .blurb {
+      border: 1px solid rgba(186, 210, 255, 0.28);
+      border-radius: var(--radius-md);
+      padding: 1.2rem;
+      background: rgba(8, 10, 30, 0.65);
+      box-shadow: var(--shadow-card);
+    }
+    .blurb blockquote {
+      margin: 0 0 0.6rem;
+      font-size: 1.05rem;
+      color: var(--ink);
+    }
   </style>
-
-  <!-- Load data BEFORE scripting -->
-  <script src="./js/data/data.js"></script>
+  <script defer src="./js/data/data.js"></script>
 </head>
-<body class="page">
+<body class="page page--books">
   <div class="shell">
-    <header class="site-header">
+    <header class="site-header" aria-label="Site">
       <a class="brand" href="./index.html">Michael C. Barros</a>
-      <nav class="nav" aria-label="Main">
-        <a href="./about.html">About</a>
-        <a href="./books.html" aria-current="page">Books</a>
-        <a id="nav-blog" href="https://mythonoesis.substack.com/" target="_blank" rel="noopener">Blog</a>
-        <a href="./projects.html">Projects</a>
-        <a id="nav-research" href="#" target="_blank" rel="noopener">Research</a>
-        <a href="./contact.html">Contact</a>
+      <nav class="nav" aria-label="Primary">
+        <a class="nav__link" href="./about.html">About</a>
+        <a class="nav__link" href="./books.html" aria-current="page">Books</a>
+        <a class="nav__link" id="nav-blog" href="https://mythonoesis.substack.com/" target="_blank" rel="noopener">Blog</a>
+        <a class="nav__link" href="./projects.html">Projects</a>
+        <a class="nav__link" id="nav-research" href="#" target="_blank" rel="noopener">Research</a>
+        <a class="nav__link" href="./contact.html">Contact</a>
       </nav>
     </header>
 
-    <section>
-      <h1 class="page-title">Books</h1>
-      <p class="muted">Published and forthcoming work on religion and popular culture.</p>
-    </section>
+    <main>
+      <section class="page-header">
+        <span class="eyebrow">Books</span>
+        <h1 class="page-title">Theology, myth, and the popular imagination</h1>
+        <p class="page-kicker">Published and forthcoming work exploring how sacred imagination moves through games, film, and speculative fiction.</p>
+      </section>
 
-    <div class="divider"></div>
-
-    <!-- Featured book -->
-    <section aria-labelledby="featured-heading">
-      <h2 id="featured-heading" style="margin:0 0 .6rem">Featured</h2>
-      <div class="book-hero" id="book-hero">
-        <img class="book-cover" src="./assets/images/books/placeholder.jpg" alt="Book cover" loading="lazy">
-        <div class="book-head">
-          <h2>Current Book</h2>
-          <p class="muted">Add book details in <code>js/data/data.js</code>.</p>
-          <div class="cta-row">
-            <a class="btn" href="#" id="buy-link" target="_blank" rel="noopener">Buy on Amazon</a>
-          </div>
+      <section aria-labelledby="featured-heading">
+        <div class="section-heading">
+          <h2 id="featured-heading">Featured</h2>
         </div>
-      </div>
+        <article class="section-card">
+          <div class="book-hero" id="book-hero">
+            <img class="book-cover" src="data:image/svg+xml;charset=UTF-8,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20viewBox%3D%270%200%20400%20600%27%3E%3Cdefs%3E%3ClinearGradient%20id%3D%27g%27%20x1%3D%270%27%20y1%3D%270%27%20x2%3D%271%27%20y2%3D%271%27%3E%3Cstop%20offset%3D%270%25%27%20stop-color%3D%27%23c084fc%27/%3E%3Cstop%20offset%3D%27100%25%27%20stop-color%3D%27%2338bdf8%27/%3E%3C/linearGradient%3E%3C/defs%3E%3Crect%20width%3D%27400%27%20height%3D%27600%27%20fill%3D%27%23080b1f%27/%3E%3Crect%20x%3D%2736%27%20y%3D%2740%27%20width%3D%27328%27%20height%3D%27520%27%20rx%3D%2736%27%20fill%3D%27url%28%23g%29%27%20opacity%3D%270.88%27/%3E%3Ctext%20x%3D%2750%25%27%20y%3D%2752%25%27%20text-anchor%3D%27middle%27%20dominant-baseline%3D%27middle%27%20font-family%3D%27Playfair%20Display%2C%20serif%27%20font-size%3D%2748%27%20fill%3D%27%23f5f6ff%27%20letter-spacing%3D%274%27%3EMyth%3C/text%3E%3C/svg%3E" alt="Book cover" loading="lazy" />
+            <div class="book-copy">
+              <h3>Current Book</h3>
+              <p class="muted">Add book details in <code>js/data/data.js</code>.</p>
+              <div class="cta-row">
+                <a class="btn" href="#" id="buy-link" target="_blank" rel="noopener">Buy</a>
+              </div>
+            </div>
+          </div>
+          <div id="book-extras" class="detail-grid" style="margin-top: 2rem; display: none;">
+            <div class="book-copy" id="book-desc"></div>
+            <div class="detail-grid" id="book-blurbs"></div>
+          </div>
+        </article>
+      </section>
 
-      <!-- Description + blurbs -->
-      <div id="book-extras" class="more-wrap" style="display:none">
-        <div class="desc" id="book-desc"></div>
-        <div class="blurbs" id="book-blurbs"></div>
-      </div>
-    </section>
+      <section id="more-books" style="display: none; margin-top: 3rem;">
+        <div class="section-heading">
+          <h2>More titles</h2>
+        </div>
+        <div class="grid cols-3" id="books-grid"></div>
+      </section>
+    </main>
 
-    <!-- More books (hidden when there’s only one) -->
-    <section id="more-books" class="more-wrap" style="display:none">
-      <h2>More Books</h2>
-      <div class="grid cols-3" id="books-grid"></div>
-    </section>
-
-    <footer class="footer">© <span id="year"></span> Michael C. Barros</footer>
+    <footer>© <span id="year"></span> Michael C. Barros</footer>
   </div>
 
   <script>
-    // External links from data
-    (function(){
-      const LINKS = (window.SITE_DATA && window.SITE_DATA.links) || window.LINKS || {};
-      document.getElementById('nav-blog').href     = LINKS.blog || 'https://mythonoesis.substack.com/';
-      document.getElementById('nav-research').href = LINKS.research || 'https://www.researchgate.net/';
-      document.getElementById('year').textContent  = new Date().getFullYear();
-    })();
+    window.addEventListener('DOMContentLoaded', () => {
+      const year = document.getElementById('year');
+      if (year) year.textContent = new Date().getFullYear();
 
-    // Books rendering
-    (function(){
       const books = (window.SITE_DATA && window.SITE_DATA.books) || [];
       if (!books.length) return;
 
       const featured = books.find(b => b.featured) || books[0];
-
-      // Hero
       const hero = document.getElementById('book-hero');
-      const cover = featured.cover || featured.image || './assets/images/books/placeholder.jpg';
+      if (!hero) return;
+      const FALLBACK_COVER =
+        'data:image/svg+xml;charset=UTF-8,' +
+        encodeURIComponent(`
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 600">
+            <defs>
+              <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+                <stop offset="0%" stop-color="#c084fc" />
+                <stop offset="100%" stop-color="#38bdf8" />
+              </linearGradient>
+            </defs>
+            <rect width="400" height="600" fill="#080b1f" />
+            <rect x="36" y="40" width="328" height="520" rx="36" fill="url(#g)" opacity="0.88" />
+            <text x="50%" y="52%" text-anchor="middle" dominant-baseline="middle" font-family="Playfair Display, serif" font-size="48" fill="#f5f6ff" letter-spacing="4">Myth</text>
+          </svg>
+        `);
+      const cover = featured.cover || featured.image || FALLBACK_COVER;
       const status = featured.status ? `<span class="status-pill">${featured.status}</span>` : '';
       const buy = (featured.buy_links && featured.buy_links[0]) ? featured.buy_links[0] : null;
 
       hero.innerHTML = `
-        <img class="book-cover" src="${cover}" alt="${featured.title} cover" loading="lazy">
-        <div class="book-head">
+        <img class="book-cover" src="${cover}" alt="${featured.title} cover" loading="lazy" />
+        <div class="book-copy">
           <div>${status}</div>
-          <h2>${featured.title}</h2>
-          ${featured.summary ? `<p class="muted">${featured.summary}</p>` : ``}
+          <h3>${featured.title}</h3>
+          ${featured.summary ? `<p class="muted">${featured.summary}</p>` : ''}
           <div class="cta-row">
-            ${buy ? `<a class="btn" href="${buy.url}" target="_blank" rel="noopener">${buy.label || 'Buy'}</a>` : ``}
+            ${buy ? `<a class="btn" href="${buy.url}" target="_blank" rel="noopener">${buy.label || 'Buy'}</a>` : ''}
+            <a class="btn ghost" href="${featured.url || './books.html'}">Details</a>
           </div>
         </div>
       `;
 
-      // Description + blurbs
       const extras = document.getElementById('book-extras');
       const descEl = document.getElementById('book-desc');
       const blurbsEl = document.getElementById('book-blurbs');
 
       const paragraphs = (featured.description || '')
-        .split(/\n{2,}/).map(s=>s.trim()).filter(Boolean);
+        .split(/\n{2,}/)
+        .map(s => s.trim())
+        .filter(Boolean);
 
-      if (paragraphs.length) {
+      if (paragraphs.length && descEl) {
         descEl.innerHTML = paragraphs.map(p => `<p>${p}</p>`).join('');
       }
 
       const reviews = featured.reviews || [];
-      if (reviews.length) {
-        blurbsEl.innerHTML = reviews.slice(0,2).map(r => `
+      if (reviews.length && blurbsEl) {
+        blurbsEl.innerHTML = reviews.slice(0, 2).map(r => `
           <div class="blurb">
-            <blockquote>“${(r.quote || '').replace(/^"|”$/g,'')}”</blockquote>
-            <small>— ${r.source || 'Reviewer'}</small>
+            <blockquote>“${(r.quote || '').replace(/^"|”$/g, '')}”</blockquote>
+            <small class="muted">— ${r.source || 'Reviewer'}</small>
           </div>
         `).join('');
       }
 
-      if (paragraphs.length || reviews.length) {
-        extras.style.display = 'block';
+      if ((paragraphs.length || reviews.length) && extras) {
+        extras.style.display = 'grid';
       }
 
-      // More books (only if you add more later)
       const others = books.filter(b => b !== featured);
       if (others.length) {
         const wrap = document.getElementById('more-books');
         const grid = document.getElementById('books-grid');
-        grid.innerHTML = others.map(b => `
-          <article class="card">
-            <div style="display:flex; gap:12px">
-              ${b.cover ? `<img src="${b.cover}" alt="" style="width:80px;height:auto;border-radius:8px">` : ``}
-              <div>
-                <div class="status-pill">${b.status || 'Book'}</div>
-                <h3 style="margin:.35rem 0 .2rem">${b.title}</h3>
-                ${b.summary ? `<p class="muted">${b.summary}</p>` : ``}
-                ${(b.buy_links && b.buy_links[0]) ? `<p style="margin-top:.4rem"><a class="btn btn-sm" style="padding:.5rem .8rem" href="${b.buy_links[0].url}" target="_blank" rel="noopener">${b.buy_links[0].label || 'Buy'}</a></p>` : ``}
+        if (wrap && grid) {
+          grid.innerHTML = others.map(b => `
+            <article class="card">
+              <div class="feature-copy">
+                ${b.cover ? `<img src="${b.cover}" alt="" style="width: 100%; max-width: 140px; border-radius: var(--radius-sm); box-shadow: 0 16px 32px rgba(8, 10, 32, 0.55);">` : ''}
+                <div>
+                  <div class="meta-row">
+                    <span class="status-pill">${b.status || 'Book'}</span>
+                  </div>
+                  <h3>${b.title}</h3>
+                  ${b.summary ? `<p>${b.summary}</p>` : ''}
+                  ${(b.buy_links && b.buy_links[0]) ? `<a class="btn ghost" style="margin-top: 0.6rem;" href="${b.buy_links[0].url}" target="_blank" rel="noopener">${b.buy_links[0].label || 'Buy'}</a>` : ''}
+                </div>
               </div>
-            </div>
-          </article>
-        `).join('');
-        wrap.style.display = 'block';
+            </article>
+          `).join('');
+          wrap.style.display = 'block';
+        }
       }
-    })();
+    });
   </script>
+  <script defer src="./js/nav.js"></script>
 </body>
 </html>

--- a/contact.html
+++ b/contact.html
@@ -1,86 +1,96 @@
 <!doctype html>
 <html lang="en">
 <head>
-  <meta charset="utf-8"/>
-  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Contact — Michael C. Barros</title>
-  <link rel="stylesheet" href="./style.css">
+  <meta name="description" content="Get in touch with Michael C. Barros for speaking, media, or collaboration." />
+  <link rel="stylesheet" href="./style.css" />
   <style>
-    :root{ --ink:#111827; --muted:#6b7280 }
-    .shell{max-width:720px;margin:0 auto;padding:24px 20px 48px}
-    .site-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:12px}
-    .brand{font-weight:700;text-decoration:none;color:var(--ink)}
-    .nav{display:flex;gap:18px;flex-wrap:wrap}
-    .nav a{color:var(--ink);text-decoration:none}
-    .nav a[aria-current="page"]{text-decoration:underline}
-    .muted{color:var(--muted)}
-    .card{background:#fff;border:1px solid #e5e7eb;border-radius:.85rem;padding:16px}
-    .btn{display:inline-block;padding:.6rem 1rem;border-radius:.6rem;background:#111827;color:#fff;text-decoration:none;font-weight:700}
-    .btn.ghost{background:transparent;color:#111827;border:2px solid #111827}
-    .row{display:flex;gap:.6rem;flex-wrap:wrap;align-items:center}
-    code.addr{padding:.25rem .4rem;background:#f8f8f8;border:1px solid #e5e7eb;border-radius:.4rem}
+    .contact-grid {
+      display: grid;
+      gap: 1.5rem;
+    }
+    .contact-actions {
+      display: flex;
+      gap: 0.75rem;
+      flex-wrap: wrap;
+      align-items: center;
+    }
   </style>
 </head>
-<body>
+<body class="page page--contact">
   <div class="shell">
-    <header class="site-header">
+    <header class="site-header" aria-label="Site">
       <a class="brand" href="./index.html">Michael C. Barros</a>
-      <nav class="nav" aria-label="Main">
-        <a href="./about.html">About</a>
-        <a href="./books.html">Books</a>
-        <a id="nav-blog" href="https://mythonoesis.substack.com/" target="_blank" rel="noopener">Blog</a>
-        <a href="./projects.html">Projects</a>
-        <a id="nav-research" href="#" target="_blank" rel="noopener">Research</a>
-        <a href="./contact.html" aria-current="page">Contact</a>
+      <nav class="nav" aria-label="Primary">
+        <a class="nav__link" href="./about.html">About</a>
+        <a class="nav__link" href="./books.html">Books</a>
+        <a class="nav__link" id="nav-blog" href="https://mythonoesis.substack.com/" target="_blank" rel="noopener">Blog</a>
+        <a class="nav__link" href="./projects.html">Projects</a>
+        <a class="nav__link" id="nav-research" href="#" target="_blank" rel="noopener">Research</a>
+        <a class="nav__link" href="./contact.html" aria-current="page">Contact</a>
       </nav>
     </header>
 
     <main>
-      <h1>Contact</h1>
-      <p class="muted">Speaking invitations, media requests, or collaboration.</p>
+      <section class="page-header">
+        <span class="eyebrow">Contact</span>
+        <h1 class="page-title">Invite the conversation</h1>
+        <p class="page-kicker">Speaking invitations, media requests, or collaboration inquiries. Share your event details, timeline, and goals.</p>
+      </section>
 
-      <div class="card">
-        <h2>Email</h2>
-        <p class="muted">I read all messages and reply as time permits.</p>
-        <div class="row">
-          <code id="addr" class="addr">michael<span aria-hidden="true">[at]</span>example<span aria-hidden="true">[dot]</span>com</code>
-          <button id="copy" class="btn">Copy</button>
-          <a id="mailto" class="btn ghost" href="#">Open mail app</a>
-        </div>
-      </div>
+      <section class="contact-grid">
+        <article class="section-card">
+          <h2>Email</h2>
+          <p>I read every message and respond as time permits.</p>
+          <div class="contact-actions">
+            <code id="addr">michael@example.com</code>
+            <button id="copy" class="btn" type="button">Copy</button>
+            <a id="mailto" class="btn ghost" href="#">Open mail app</a>
+          </div>
+        </article>
 
-      <div class="divider"></div>
-
-      <div class="card">
-        <h2>Speaking</h2>
-        <p>Interested in a lecture or interview on religion & popular culture, games, or speculative fiction? Provide proposed date(s), audience, and format.</p>
-      </div>
+        <article class="section-card">
+          <h2>Speaking &amp; media</h2>
+          <p>For lectures, interviews, or workshops on religion &amp; popular culture, please include proposed dates, audience, and format. I can tailor talks for academic, community, or industry settings.</p>
+        </article>
+      </section>
     </main>
 
-    <footer class="footer" style="text-align:center;color:var(--muted);margin-top:32px;font-size:.95rem">
-      © <span id="year"></span> Michael C. Barros
-    </footer>
+    <footer>© <span id="year"></span> Michael C. Barros</footer>
   </div>
 
   <script defer src="./js/data/data.js"></script>
+  <script defer src="./js/nav.js"></script>
   <script>
-    // Pull configured links + email from data.js
-    const LINKS=(window.SITE_DATA&&SITE_DATA.links)||window.LINKS||{};
-    const EMAIL=(window.SITE_DATA&&SITE_DATA.contact&&SITE_DATA.contact.email)||"michael@example.com";
-    document.getElementById('nav-blog').href = LINKS.blog || 'https://mythonoesis.substack.com/';
-    document.getElementById('nav-research').href = LINKS.research || 'https://www.researchgate.net/';
-    document.getElementById('year').textContent = new Date().getFullYear();
+    window.addEventListener('DOMContentLoaded', () => {
+      const LINKS = (window.SITE_DATA && window.SITE_DATA.links) || window.LINKS || {};
+      const EMAIL = (window.SITE_DATA && window.SITE_DATA.contact && window.SITE_DATA.contact.email) || 'michael@example.com';
 
-    // Simple obfuscation replacement + copy
-    const addrEl=document.getElementById('addr');
-    addrEl.textContent = EMAIL;
-    document.getElementById('mailto').href = `mailto:${EMAIL}`;
-    document.getElementById('copy').addEventListener('click', async ()=>{
-      try { await navigator.clipboard.writeText(EMAIL); }
-      catch {}
-      const b = document.getElementById('copy');
-      b.textContent = "Copied";
-      setTimeout(()=> b.textContent = "Copy", 1200);
+      const blog = document.getElementById('nav-blog');
+      if (blog) blog.href = LINKS.blog || 'https://mythonoesis.substack.com/';
+      const research = document.getElementById('nav-research');
+      if (research) research.href = LINKS.research || 'https://www.researchgate.net/';
+
+      const addrEl = document.getElementById('addr');
+      if (addrEl) addrEl.textContent = EMAIL;
+
+      const mailto = document.getElementById('mailto');
+      if (mailto) mailto.href = `mailto:${EMAIL}`;
+
+      const copy = document.getElementById('copy');
+      if (copy) {
+        copy.addEventListener('click', async () => {
+          try { await navigator.clipboard.writeText(EMAIL); }
+          catch {}
+          copy.textContent = 'Copied';
+          setTimeout(() => { copy.textContent = 'Copy'; }, 1200);
+        });
+      }
+
+      const year = document.getElementById('year');
+      if (year) year.textContent = new Date().getFullYear();
     });
   </script>
 </body>

--- a/index.html
+++ b/index.html
@@ -1,331 +1,288 @@
 <!doctype html>
 <html lang="en">
 <head>
-  <meta charset="utf-8"/>
-  <meta name="viewport" content="width=device-width, initial-scale=1"/>
-  <title>Michael C. Barros — Scholar of Religion & Popular Culture</title>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Michael C. Barros — Scholar of Myth, Media, and Esoteric Imagination</title>
+  <meta name="description" content="Scholar of religion and popular culture exploring the luminous edges of myth, media, and the sacred." />
+  <meta name="theme-color" content="#050310" />
 
-  <meta name="description" content="Where myth and meaning surface in games, film, and fiction. Books, selected writing, media, and speaking.">
-  <meta name="theme-color" content="#1f2937">
-
-  <link rel="stylesheet" href="./style.css">
-
-  <style>
-    /* Light augmentation that cooperates with style.css */
-    :root{
-      --ink:#111827; --muted:#6b7280; --accent:#0f766e; --bg:#F7F4EE; --card:#fff; --ring:rgba(15,118,110,.25);
-    }
-    body{background:var(--bg);color:var(--ink)}
-    .shell{max-width:1060px;margin:0 auto;padding:20px 20px 48px}
-
-    /* Header / nav */
-    .site-header{display:flex;align-items:center;justify-content:space-between;padding:10px 0}
-    .brand{font-weight:700;text-decoration:none;color:var(--ink)}
-    .nav{display:flex;gap:18px;flex-wrap:wrap}
-    .nav a{color:var(--ink);text-decoration:none}
-    .nav a:hover{text-decoration:underline}
-
-    /* Hero */
-    .hero{padding:42px 0 20px;text-align:center}
-    .hero h1{margin:.25rem 0 .4rem;font-size:clamp(1.8rem,2.8vw,2.6rem)}
-    .tagline{color:var(--muted);min-height:1.6em;transition:opacity .35s}
-    .cta-row{display:flex;gap:.75rem;justify-content:center;flex-wrap:wrap;margin-top:14px}
-    .btn{display:inline-block;padding:.7rem 1.1rem;border-radius:.7rem;background:var(--ink);color:#fff;text-decoration:none;font-weight:700}
-    .btn:hover{filter:brightness(1.08)}
-    .btn.ghost{background:transparent;color:var(--ink);border:2px solid var(--ink)}
-    .divider{height:1px;background:#e5e7eb;margin:28px 0}
-
-    /* Cards */
-    .grid{display:grid;gap:16px}
-    @media(min-width:900px){.grid.cols-3{grid-template-columns:repeat(3,1fr)}.grid.cols-2{grid-template-columns:repeat(2,1fr)}}
-    .card{background:var(--card);border:1px solid rgba(160,125,59,.25);border-radius:12px;padding:16px;transition:.2s;color:inherit;text-decoration:none;display:block}
-    .card:hover{border-color:rgba(160,125,59,.5);box-shadow:0 10px 26px rgba(0,0,0,.08);transform:translateY(-2px)}
-    .badge{display:inline-block;border:1px solid rgba(160,125,59,.35);color:var(--accent);font-family:'IBM Plex Mono',monospace;font-size:.72rem;padding:.15rem .45rem;border-radius:.4rem;margin-bottom:.35rem}
-
-    /* Flip card (for projects / writing previews) */
-    .flip{perspective:1000px}
-    .flip-inner{position:relative;transform-style:preserve-3d;transition:transform .5s}
-    .flip:hover .flip-inner{transform:rotateY(180deg)}
-    .flip-face{backface-visibility:hidden}
-    .flip-back{position:absolute;inset:0;transform:rotateY(180deg)}
-    .flip-face,.flip-back{border-radius:12px;border:1px solid rgba(160,125,59,.25);padding:16px;background:#fff}
-
-    .section-head{display:flex;align-items:baseline;justify-content:space-between;margin:0 0 .6rem}
-    .section-head h2{margin:0;font-size:1.25rem}
-    .section-head a{color:var(--accent);text-decoration:none;font-weight:600}
-    .section-head a:hover{text-decoration:underline}
-
-    /* --- Featured Book container ("dynamic box") --- */
-    .section-card{
-      background:#fff;
-      border:1px solid rgba(160,125,59,.25);
-      border-radius:16px;
-      box-shadow:0 8px 26px rgba(0,0,0,.06);
-      padding:18px;
-    }
-    @media (min-width:900px){ .section-card{ padding:22px 22px; } }
-
-/* --- Featured Book layout --- */
-.section-card{
-  background:#fff;
-  border:1px solid rgba(160,125,59,.25);
-  border-radius:16px;
-  box-shadow:0 8px 26px rgba(0,0,0,.06);
-  padding:18px;
-}
-@media (min-width:900px){ .section-card{ padding:22px 22px; } }
-
-.book-hero{
-  display:grid;
-  gap:24px;                 /* a touch more breathing room */
-  align-items:start;        /* grid items start at the top */
-}
-@media (min-width:900px){
-  .book-hero{ grid-template-columns: 380px 1fr; }  /* was 360 */
-}
-@media (min-width:1280px){
-  .book-hero{ grid-template-columns: 420px 1fr; }  /* was 400 */
-}
-
-.book-cover{
-  display:block;            /* prevents inline-img baseline jiggle */
-  width:100%;
-  height:auto;
-  border-radius:12px;
-  box-shadow:0 12px 30px rgba(0,0,0,.12);
-  background:#fff;
-  object-fit:contain;
-  align-self:start;         /* top-align the image within the grid cell */
-  margin:0;                 /* guard against UA margins */
-}
-
-.book-copy{
-  align-self:start;         /* top-align the text column too */
-  display:flex;
-  flex-direction:column;
-  gap:.6rem;
-}
-
-.book-copy h3{ margin:.2rem 0 0; font-size:1.55rem; } /* no top bump */
-.book-copy .muted{ margin-bottom:.35rem; }
-.book-copy .book-desc{ margin-top:.4rem; max-width:72ch; }
-.book-desc p{ margin:.65rem 0; line-height:1.7; }
-
-
-    .footer{text-align:center;color:var(--muted);margin-top:32px;font-size:.95rem}
-  </style>
+  <link rel="stylesheet" href="./style.css" />
 </head>
 
-<body>
+<body class="home">
   <div class="shell">
-    <!-- HEADER -->
-    <header class="site-header">
+    <header class="site-header" aria-label="Site">
       <a class="brand" href="./index.html">Michael C. Barros</a>
-      <nav class="nav" aria-label="Main">
-        <a href="./about.html">About</a>
-        <a href="./books.html">Books</a>
-        <a id="nav-blog" href="#" target="_blank" rel="noopener">Blog</a>
-        <a href="./projects.html">Projects</a>
-        <a id="nav-research" href="#" target="_blank" rel="noopener">Research</a>
-        <a href="./contact.html">Contact</a>
+      <nav class="nav" aria-label="Primary">
+        <a class="nav__link" href="./about.html">About</a>
+        <a class="nav__link" href="./books.html">Books</a>
+        <a class="nav__link" id="nav-blog" href="#" target="_blank" rel="noopener">Blog</a>
+        <a class="nav__link" href="./projects.html">Projects</a>
+        <a class="nav__link" id="nav-research" href="#" target="_blank" rel="noopener">Research</a>
+        <a class="nav__link" href="./contact.html">Contact</a>
       </nav>
     </header>
 
-    <!-- HERO -->
-    <section class="hero" aria-labelledby="title">
-      <h1 id="title">Michael C. Barros</h1>
-      <p id="rotating" class="tagline">
-        Where myth and meaning surface in games, film, and fiction.
-      </p>
-      <div class="cta-row" role="group" aria-label="Primary actions">
-        <a class="btn" href="./books.html">Explore Books →</a>
-        <a class="btn ghost" id="cta-blog" href="#" target="_blank" rel="noopener">Visit Substack →</a>
-      </div>
-    </section>
-
-    <div class="divider" role="presentation"></div>
-
-<!-- FEATURED BOOK -->
-<section aria-labelledby="book-heading">
-  <div class="section-head">
-    <h2 id="book-heading">Featured Book</h2>
-    <a href="./books.html" style="color:var(--brand);text-decoration:none;font-weight:600">All books →</a>
-  </div>
-
-  <div class="feature-box">
-    <div class="feature-grid" id="book-hero">
-      <!-- JS will inject cover + copy + full description -->
-      <div class="feature-media"><img src="./assets/images/books/placeholder.jpg" alt="Book cover" loading="lazy"></div>
-      <div class="feature-body">
-        <h3>Your Current Book</h3>
-        <p class="muted">Add details in <code>js/data/data.js</code> to populate this section.</p>
-        <div class="cta-row">
-          <a class="btn" href="./books.html">Learn more</a>
-          <a class="btn ghost" href="./books.html">Buy</a>
-        </div>
-        <div class="desc"></div>
-      </div>
-    </div>
-  </div>
-</section>
-
-
-    <div class="divider" role="presentation"></div>
-
-    <!-- PROJECTS -->
-    <section aria-labelledby="projects-heading">
-      <div class="section-head">
-        <h2 id="projects-heading">Projects</h2>
-        <a href="./projects.html">More →</a>
-      </div>
-      <div class="grid cols-3" id="projects-grid">
-        <!-- Fallback static cards; JS will replace if projects exist -->
-        <div class="flip">
-          <div class="flip-inner">
-            <div class="flip-face">
-              <span class="badge">Waypoint</span>
-              <h3>Waypoint Institute</h3>
-              <p class="muted">Research and publishing initiative (coming soon).</p>
+    <main>
+      <section class="hero" aria-labelledby="home-title">
+        <div class="hero__content">
+          <span class="eyebrow">Myth + Media Praxis</span>
+          <h1 id="home-title">Mapping the sacred across popular culture.</h1>
+          <p id="rotating" class="hero__tagline">
+            Where myth and meaning surface in games, film, and fiction.
+          </p>
+          <div class="hero__meta">
+            <div class="badge-row" aria-label="Areas of focus">
+              <span class="badge">Games</span>
+              <span class="badge">Film</span>
+              <span class="badge">Speculative Fiction</span>
             </div>
-            <div class="flip-back">
-              <h3>Waypoint Institute</h3>
-              <p class="muted">A space for myth, meaning, and media praxis. Learn more →</p>
+            <div class="cta-row" role="group" aria-label="Primary actions">
+              <a class="btn" href="./books.html">Explore Books →</a>
+              <a class="btn ghost" id="cta-blog" href="#" target="_blank" rel="noopener">Visit Substack →</a>
             </div>
           </div>
         </div>
-        <a class="card" href="./books.html">
-          <span class="badge">In Progress</span>
-          <h3>Zelda & Religion</h3>
-          <p class="muted">Time, sacrifice, and mythopoesis in The Legend of Zelda.</p>
-        </a>
-        <a class="card" href="./books.html">
-          <span class="badge">Forthcoming</span>
-          <h3>The Esoteric Theology of Philip K. Dick</h3>
-          <p class="muted">Metaphysics of time and the sacred in PKD.</p>
-        </a>
-      </div>
-    </section>
+        <div class="hero__media" aria-hidden="true">
+          <div class="hero__orb">
+            <div class="hero__glyph">✶</div>
+          </div>
+        </div>
+      </section>
 
-    <div class="divider" role="presentation"></div>
+      <div class="divider" role="presentation"></div>
 
-    <!-- MEDIA / LATEST FROM SUBSTACK -->
-    <section aria-labelledby="media-heading">
-      <div class="section-head">
-        <h2 id="media-heading">Latest from Substack</h2>
-        <a id="open-substack" href="#" target="_blank" rel="noopener">Open Substack →</a>
-      </div>
-      <div class="grid cols-3" id="substack-cards"></div>
-    </section>
+      <section aria-labelledby="book-heading">
+        <div class="section-heading">
+          <h2 id="book-heading">Featured Book</h2>
+          <a class="link" href="./books.html">All books →</a>
+        </div>
+        <article class="section-card">
+          <div class="feature-grid two-col" id="book-hero">
+            <div class="feature-media">
+              <img src="data:image/svg+xml;charset=UTF-8,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20viewBox%3D%270%200%20400%20600%27%3E%3Cdefs%3E%3ClinearGradient%20id%3D%27g%27%20x1%3D%270%27%20y1%3D%270%27%20x2%3D%271%27%20y2%3D%271%27%3E%3Cstop%20offset%3D%270%25%27%20stop-color%3D%27%23c084fc%27/%3E%3Cstop%20offset%3D%27100%25%27%20stop-color%3D%27%2338bdf8%27/%3E%3C/linearGradient%3E%3C/defs%3E%3Crect%20width%3D%27400%27%20height%3D%27600%27%20fill%3D%27%23080b1f%27/%3E%3Crect%20x%3D%2736%27%20y%3D%2740%27%20width%3D%27328%27%20height%3D%27520%27%20rx%3D%2736%27%20fill%3D%27url%28%23g%29%27%20opacity%3D%270.88%27/%3E%3Ctext%20x%3D%2750%25%27%20y%3D%2752%25%27%20text-anchor%3D%27middle%27%20dominant-baseline%3D%27middle%27%20font-family%3D%27Playfair%20Display%2C%20serif%27%20font-size%3D%2748%27%20fill%3D%27%23f5f6ff%27%20letter-spacing%3D%274%27%3EMyth%3C/text%3E%3C/svg%3E" alt="Book cover" loading="lazy" />
+            </div>
+            <div class="book-copy">
+              <h3>Your Current Book</h3>
+              <p class="muted">Add details in <code>js/data/data.js</code> to populate this section.</p>
+              <div class="cta-row">
+                <a class="btn" href="./books.html">Learn more</a>
+                <a class="btn ghost" href="./books.html">Buy</a>
+              </div>
+              <div class="book-desc"></div>
+            </div>
+          </div>
+        </article>
+      </section>
 
-    <footer class="footer">© <span id="year"></span> Michael C. Barros</footer>
+      <div class="divider" role="presentation"></div>
+
+      <section aria-labelledby="projects-heading">
+        <div class="section-heading">
+          <h2 id="projects-heading">Projects</h2>
+          <a class="link" href="./projects.html">Browse all →</a>
+        </div>
+        <div class="grid cols-3" id="projects-grid">
+          <a class="card" href="./projects.html">
+            <span class="badge">Waypoint</span>
+            <h3>Waypoint Institute</h3>
+            <p>Research and publishing initiative (coming soon).</p>
+          </a>
+          <a class="card" href="./books.html">
+            <span class="badge">In Progress</span>
+            <h3>Zelda &amp; Religion</h3>
+            <p>Time, sacrifice, and mythopoesis in The Legend of Zelda.</p>
+          </a>
+          <a class="card" href="./books.html">
+            <span class="badge">Forthcoming</span>
+            <h3>The Esoteric Theology of Philip K. Dick</h3>
+            <p>Metaphysics of time and the sacred in PKD.</p>
+          </a>
+        </div>
+      </section>
+
+      <div class="divider" role="presentation"></div>
+
+      <section aria-labelledby="media-heading">
+        <div class="section-heading">
+          <h2 id="media-heading">Latest from Substack</h2>
+          <a class="link" id="open-substack" href="#" target="_blank" rel="noopener">Open Substack →</a>
+        </div>
+        <div class="grid cols-3" id="substack-cards">
+          <div class="empty" style="grid-column: 1/-1;">
+            Add posts in <code>js/data/data.js</code> to surface Substack updates.
+          </div>
+        </div>
+      </section>
+
+      <div class="divider" role="presentation"></div>
+
+      <section aria-labelledby="bio-heading">
+        <article class="section-card">
+          <div class="feature-grid two-col">
+            <div class="feature-media feature-media--avatar" role="img" aria-label="Abstract portrait of Michael C. Barros"></div>
+            <div class="feature-body">
+              <span class="eyebrow">About Michael</span>
+              <h3 id="bio-heading">Scholar of religion &amp; popular culture</h3>
+              <p>Exploring how sacred imagination moves through games, film, and speculative fiction—tracing the esoteric threads that surface in contemporary storytelling.</p>
+              <div class="cta-row">
+                <a class="btn ghost" href="./about.html">Read full bio</a>
+                <a class="btn" href="./contact.html">Connect</a>
+              </div>
+            </div>
+          </div>
+        </article>
+      </section>
+    </main>
+
+    <footer>© <span id="year"></span> Michael C. Barros</footer>
   </div>
 
-  <!-- Data + shared nav config -->
   <script defer src="./js/data/data.js"></script>
   <script defer src="./js/nav.js"></script>
-
   <script>
     window.addEventListener('DOMContentLoaded', () => {
-      // --- rotating tagline ---
+      // rotating tagline
       (function(){
         const el = document.getElementById('rotating');
         const lines = (window.SITE_DATA && window.SITE_DATA.taglines) || [
-          "Where myth and meaning surface in games, film, and fiction.",
-          "Exploring how culture becomes a site of religious experience.",
-          "Religion, imagination, and popular culture."
+          'Where myth and meaning surface in games, film, and fiction.',
+          'Exploring how culture becomes a site of religious experience.',
+          'Religion, imagination, and popular culture.'
         ];
+        if (!el) return;
         let i = 0;
-        setInterval(()=>{ i=(i+1)%lines.length; el.style.opacity=0; setTimeout(()=>{ el.textContent = lines[i]; el.style.opacity=1; },180);}, 4200);
+        const reduceMotion = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+        if (lines.length < 2 || reduceMotion) {
+          el.textContent = lines[0];
+          return;
+        }
+        el.textContent = lines[0];
+        setInterval(() => {
+          i = (i + 1) % lines.length;
+          el.style.opacity = 0;
+          setTimeout(() => {
+            el.textContent = lines[i];
+            el.style.opacity = 1;
+          }, 180);
+        }, 4200);
       })();
 
-      // --- footer year ---
-      document.getElementById('year').textContent = new Date().getFullYear();
+      // footer year
+      const year = document.getElementById('year');
+      if (year) year.textContent = new Date().getFullYear();
 
-      // --- featured book (bigger cover + full description; NO reviews on home) ---
+      // featured book
       (function(){
+        const FALLBACK_COVER =
+          'data:image/svg+xml;charset=UTF-8,' +
+          encodeURIComponent(`
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 600">
+              <defs>
+                <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+                  <stop offset="0%" stop-color="#c084fc" />
+                  <stop offset="100%" stop-color="#38bdf8" />
+                </linearGradient>
+              </defs>
+              <rect width="400" height="600" fill="#080b1f" />
+              <rect x="36" y="40" width="328" height="520" rx="36" fill="url(#g)" opacity="0.88" />
+              <text x="50%" y="52%" text-anchor="middle" dominant-baseline="middle" font-family="Playfair Display, serif" font-size="48" fill="#f5f6ff" letter-spacing="4">Myth</text>
+            </svg>
+          `);
+
         const books = (window.SITE_DATA && window.SITE_DATA.books) || window.BOOKS || [];
         if (!books.length) return;
-        const featured = books.find(b=>b.featured) || books[0];
+        const featured = books.find(b => b.featured) || books[0];
         const hero = document.getElementById('book-hero');
+        if (!hero) return;
 
-        const cover = featured.cover || featured.image || './assets/images/books/placeholder.jpg';
-        const url   = featured.url || './books.html';
-        const buy   = (featured.buy_links && featured.buy_links[0]) ? featured.buy_links[0] : null;
-        const desc  = featured.description || featured.summary || "";
+        const cover = featured.cover || featured.image || FALLBACK_COVER;
+        const url = featured.url || './books.html';
+        const buy = (featured.buy_links && featured.buy_links[0]) ? featured.buy_links[0] : null;
+        const desc = featured.description || featured.summary || '';
 
         hero.innerHTML = `
-          <img class="book-cover" src="${cover}" alt="${featured.title} cover" loading="lazy">
+          <div class="feature-media">
+            <img class="book-cover" src="${cover}" alt="${featured.title} cover" loading="lazy" />
+          </div>
           <div class="book-copy">
             <h3>${featured.title}</h3>
             ${featured.summary ? `<p class="muted">${featured.summary}</p>` : ``}
-            <div class="cta-row" style="justify-content:flex-start">
+            <div class="cta-row">
               <a class="btn" href="${url}">Learn more</a>
               ${buy ? `<a class="btn ghost" href="${buy.url}" target="_blank" rel="noopener">${buy.label || 'Buy'}</a>` : ``}
             </div>
             <div class="book-desc">
-              ${desc.split(/\n{2,}/).map(p=>`<p>${p.trim()}</p>`).join("")}
+              ${desc.split(/\n{2,}/).map(p => `<p>${p.trim()}</p>`).join('')}
             </div>
           </div>
         `;
       })();
 
-      // --- projects (flip cards) ---
+      // projects
       (function(){
         const projects = (window.SITE_DATA && window.SITE_DATA.projects) || window.PROJECTS || [];
-        if (!projects.length) return; // keep the static 3
+        if (!projects.length) return;
         const grid = document.getElementById('projects-grid');
+        if (!grid) return;
         grid.innerHTML = '';
-        projects.slice(0,6).forEach(p=>{
+        projects.slice(0, 6).forEach(p => {
           if (p.description) {
-            const c = document.createElement('div');
-            c.className = 'flip';
-            c.innerHTML = `
-              <a class="flip-inner" href="${p.url || '#'}" ${p.external ? 'target="_blank" rel="noopener"':''}>
-                <div class="flip-face">
+            const card = document.createElement('div');
+            card.className = 'flip';
+            card.innerHTML = `
+              <div class="flip-inner">
+                <a class="flip-face" href="${p.url || '#'}" ${p.external ? 'target="_blank" rel="noopener"' : ''}>
                   <span class="badge">${p.status || p.type || 'Project'}</span>
                   <h3>${p.title}</h3>
-                  <p class="muted">${p.short || p.summary || ''}</p>
-                </div>
-                <div class="flip-back">
+                  <p>${p.short || p.summary || ''}</p>
+                </a>
+                <a class="flip-back" href="${p.url || '#'}" ${p.external ? 'target="_blank" rel="noopener"' : ''}>
                   <h3>${p.title}</h3>
-                  ${p.description ? `<p class="muted">${p.description}</p>` : ``}
-                </div>
-              </a>`;
-            grid.appendChild(c);
+                  ${p.description ? `<p>${p.description}</p>` : ''}
+                </a>
+              </div>
+            `;
+            grid.appendChild(card);
           } else {
-            const a = document.createElement('a');
-            a.className = 'card';
-            a.href = p.url || '#';
-            if (p.external) { a.target = "_blank"; a.rel = "noopener"; }
-            a.innerHTML = `<span class="badge">${p.status || p.type || 'Project'}</span><h3>${p.title}</h3><p class="muted">${p.short || p.summary || ''}</p>`;
-            grid.appendChild(a);
+            const link = document.createElement('a');
+            link.className = 'card';
+            link.href = p.url || '#';
+            if (p.external) { link.target = '_blank'; link.rel = 'noopener'; }
+            link.innerHTML = `
+              <span class="badge">${p.status || p.type || 'Project'}</span>
+              <h3>${p.title}</h3>
+              <p>${p.short || p.summary || ''}</p>
+            `;
+            grid.appendChild(link);
           }
         });
       })();
 
-      // --- Substack (latest 3) ---
+      // substack
       (function(){
         const feed = document.getElementById('substack-cards');
         const posts = (window.SITE_DATA?.substack?.posts || window.SUBSTACK_POSTS || [])
           .slice()
-          .sort((a,b)=> new Date(b.date)-new Date(a.date))
-          .slice(0,3);
+          .sort((a, b) => new Date(b.date) - new Date(a.date))
+          .slice(0, 3);
         const blogUrl = (window.SITE_DATA?.links?.blog) || (window.LINKS?.blog) || 'https://mythonoesis.substack.com/';
-        document.getElementById('open-substack').href = blogUrl;
-
+        const open = document.getElementById('open-substack');
+        if (open) open.href = blogUrl;
         if (!feed) return;
-        if (!posts.length){
-          feed.innerHTML = `<div class="card muted" style="grid-column:1/-1">Add posts in <code>js/data/data.js</code> (SUBSTACK_POSTS).</div>`;
-          return;
-        }
-        posts.forEach(p=>{
+        if (!posts.length) return;
+        feed.innerHTML = '';
+        posts.forEach(post => {
           const a = document.createElement('a');
           a.className = 'card';
-          a.href = p.url; a.target = "_blank"; a.rel = "noopener";
+          a.href = post.url;
+          a.target = '_blank';
+          a.rel = 'noopener';
           a.innerHTML = `
             <span class="badge">Substack</span>
-            <h3>${p.title}</h3>
-            <p class="muted">${p.summary || ''}</p>
+            <h3>${post.title}</h3>
+            ${post.summary ? `<p>${post.summary}</p>` : ''}
           `;
           feed.appendChild(a);
         });
@@ -334,20 +291,3 @@
   </script>
 </body>
 </html>
-<section aria-labelledby="bio-heading" style="margin-top:22px">
-  <div class="feature-box">
-    <div class="feature-grid" style="grid-template-columns:minmax(120px,160px) 1fr">
-      <div class="feature-media">
-        <img src="./assets/images/headshot.jpg" alt="Michael C. Barros" loading="lazy">
-      </div>
-      <div class="feature-body">
-        <h3 id="bio-heading" style="margin-top:.1rem">About Michael</h3>
-        <p class="muted">Scholar of religion & popular culture, exploring how myth and meaning surface in games, film, and fiction.</p>
-        <div class="cta-row">
-          <a class="btn ghost" href="./about.html">Read full bio</a>
-          <a class="btn" href="./contact.html">Contact</a>
-        </div>
-      </div>
-    </div>
-  </div>
-</section>

--- a/js/nav.js
+++ b/js/nav.js
@@ -1,38 +1,43 @@
-<!-- js/nav.js -->
-<script>
 (function () {
-  // Grab links from SITE_DATA (falls back to safe defaults)
   const LINKS = (window.SITE_DATA && window.SITE_DATA.links) || window.LINKS || {};
+  const blog = LINKS.blog || 'https://mythonoesis.substack.com/';
+  const research = LINKS.research || 'https://www.researchgate.net/';
 
-  function setHref(id, href) {
-    var el = document.getElementById(id);
+  [
+    { selector: '#nav-blog', href: blog },
+    { selector: '#cta-blog', href: blog },
+    { selector: '#open-substack', href: blog },
+    { selector: '#about-blog', href: blog }
+  ].forEach(({ selector, href }) => {
+    const el = document.querySelector(selector);
     if (el && href) el.setAttribute('href', href);
-  }
+  });
 
-  // Wire every place we might use these links
-  const blog   = LINKS.blog     || 'https://mythonoesis.substack.com/';
-  const rg     = LINKS.research || 'https://www.researchgate.net/';
+  [
+    { selector: '#nav-research', href: research },
+    { selector: '#about-research', href: research }
+  ].forEach(({ selector, href }) => {
+    const el = document.querySelector(selector);
+    if (el && href) el.setAttribute('href', href);
+  });
 
-  setHref('nav-blog', blog);
-  setHref('cta-blog', blog);
-  setHref('open-substack', blog);
-  setHref('nav-research', rg);
-
-  // Optional: mark active page in nav by pathname
   try {
     const path = (location.pathname || '').split('/').pop() || 'index.html';
     const map = {
-      'index.html': null,
+      'index.html': './index.html',
       'books.html': './books.html',
       'projects.html': './projects.html',
       'about.html': './about.html',
       'contact.html': './contact.html'
     };
-    const activeHref = map[path];
-    if (activeHref) {
-      const active = document.querySelector(`.nav a[href="${activeHref}"]`);
-      if (active) active.setAttribute('aria-current','page');
+    const target = map[path];
+    if (target) {
+      const link = document.querySelector(`.nav__link[href="${target}"]`);
+      if (link && !link.hasAttribute('aria-current')) {
+        link.setAttribute('aria-current', 'page');
+      }
     }
-  } catch {}
+  } catch (err) {
+    // no-op if location parsing fails
+  }
 })();
-</script>

--- a/js/projects.js
+++ b/js/projects.js
@@ -1,149 +1,161 @@
 // js/projects.js
 (function () {
-  "use strict";
+  'use strict';
 
-  // ----- Links from data.js for nav -----
-  const LINKS =
-    (window.SITE_DATA && window.SITE_DATA.links) ||
-    window.LINKS || {
-      blog: "https://mythonoesis.substack.com/",
-      research: "https://www.researchgate.net/",
-    };
-
-  const blogA = document.getElementById("nav-blog");
-  const resA = document.getElementById("nav-research");
-  if (blogA) blogA.href = LINKS.blog;
-  if (resA) resA.href = LINKS.research;
-
-  const year = document.getElementById("year");
+  const year = document.getElementById('year');
   if (year) year.textContent = new Date().getFullYear();
 
-  // ----- Utilities -----
-  const $ = (s) => document.querySelector(s);
-  const $$ = (s) => Array.from(document.querySelectorAll(s));
-  const slugify = (s) =>
-    (s || "")
-      .toLowerCase()
-      .trim()
-      .replace(/[^a-z0-9\s-]/g, "")
-      .replace(/\s+/g, "-")
-      .replace(/-+/g, "-");
-  const fmt = (iso) => {
-    try {
-      return new Date(iso).toISOString().slice(0, 10);
-    } catch {
-      return "";
-    }
-  };
+  const projects = getProjects();
+  buildFilters(projects);
 
-  // ----- Data normalization -----
+  const state = { k: 'All', q: '' };
+  renderGrid(projects, state);
+
+  const filters = document.getElementById('filters');
+  if (filters) {
+    filters.addEventListener('click', (event) => {
+      const btn = event.target.closest('button[data-k]');
+      if (!btn) return;
+      filters.querySelectorAll('button').forEach((b) => b.classList.remove('active'));
+      btn.classList.add('active');
+      state.k = btn.dataset.k || 'All';
+      renderGrid(projects, state);
+    });
+  }
+
+  const search = document.getElementById('search');
+  if (search) {
+    search.addEventListener('input', (event) => {
+      state.q = event.target.value || '';
+      renderGrid(projects, state);
+    });
+  }
+
   function getProjects() {
     const D = window.SITE_DATA || {};
-    let list = Array.isArray(D.projects) ? D.projects.slice() : window.PROJECTS || [];
+    const list = Array.isArray(D.projects) ? D.projects.slice() : window.PROJECTS || [];
     return list.map((p) => ({
-      id: p.id || slugify(p.title || ""),
-      title: p.title || "Untitled project",
-      status: p.status || p.type || "Project", // badge
-      type: p.type || "",
+      id: slugify(p.id || p.title || ''),
+      title: p.title || 'Untitled project',
+      status: p.status || p.type || 'Project',
+      type: p.type || '',
       tags: Array.isArray(p.tags)
         ? p.tags
         : p.tags
         ? String(p.tags)
-            .split(",")
+            .split(',')
             .map((t) => t.trim())
         : [],
-      date: p.date || p.started || "",
-      short: p.short || p.summary || "",
-      description: p.description || "",
+      date: p.date || p.started || '',
+      short: p.short || p.summary || '',
+      description: p.description || '',
       url: p.url || null,
+      cover: p.cover || p.image || null,
       external: !!p.external,
     }));
   }
 
-  // ----- Filters + Search -----
   function buildFilters(items) {
-    const filters = $("#filters");
-    if (!filters) return;
-    const kinds = new Set(["All"]);
+    const node = document.getElementById('filters');
+    if (!node) return;
+    const kinds = new Set(['All']);
     items.forEach((p) => {
       if (p.status) kinds.add(p.status);
       if (p.type) kinds.add(p.type);
     });
-    filters.innerHTML = "";
-    [...kinds].forEach((k, i) => {
-      const b = document.createElement("button");
-      b.type = "button";
-      b.className = "filter-btn" + (i === 0 ? " active" : "");
-      b.dataset.k = k;
-      b.textContent = k;
-      filters.appendChild(b);
+    node.innerHTML = '';
+    Array.from(kinds).forEach((kind, idx) => {
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'filter-btn' + (idx === 0 ? ' active' : '');
+      button.dataset.k = kind;
+      button.textContent = kind;
+      node.appendChild(button);
     });
   }
 
-  function renderGrid(items, { k = "All", q = "" } = {}) {
-    const grid = $("#projects-grid");
-    const empty = $("#empty");
+  function renderGrid(items, { k = 'All', q = '' } = {}) {
+    const grid = document.getElementById('projects-grid');
+    const empty = document.getElementById('empty');
     if (!grid) return;
 
     const ql = q.trim().toLowerCase();
     const filtered = items.filter((p) => {
-      const inKind = k === "All" || p.status === k || p.type === k;
-      const inSearch =
-        !ql ||
-        [p.title, p.short, p.description, p.tags.join(" ")]
-          .join(" ")
-          .toLowerCase()
-          .includes(ql);
+      const inKind = k === 'All' || p.status === k || p.type === k;
+      const haystack = [p.title, p.short, p.description, p.tags.join(' ')].join(' ').toLowerCase();
+      const inSearch = !ql || haystack.includes(ql);
       return inKind && inSearch;
     });
 
     if (!filtered.length) {
-      grid.innerHTML = "";
-      if (empty) empty.style.display = "block";
+      grid.innerHTML = '';
+      if (empty) empty.style.display = 'block';
       return;
-    } else if (empty) empty.style.display = "none";
+    }
 
-    grid.innerHTML = "";
+    if (empty) empty.style.display = 'none';
+    grid.innerHTML = '';
+
     filtered.forEach((p) => {
-     // Use flip card only when we have a cover image for a true "front"
-const hasCover = !!p.cover; // string URL expected
-if (hasCover) {
-  const c = document.createElement("div");
-  c.className = "flip";
-  c.innerHTML = `
-    <div class="flip-inner">
-      <a class="flip-face" href="${p.url || '#'}" ${p.external ? 'target="_blank" rel="noopener"':''}>
-        <img src="${p.cover}" alt="" style="width:100%;height:140px;object-fit:cover;border-radius:10px;margin-bottom:.6rem">
-        <span class="badge">${p.status}</span>
-        <h3>${p.title}</h3>
-        <div class="meta-row">
-          ${p.date ? `<time datetime="${p.date}">${fmt(p.date)}</time>` : ""}
-          ${p.tags.length ? `· ${p.tags.join(", ")}` : ""}
-        </div>
-        <p class="muted">${p.short}</p>
-      </a>
-      <a class="flip-back" href="${p.url || '#'}" ${p.external ? 'target="_blank" rel="noopener"':''}>
-        <h3>${p.title}</h3>
-        <p class="muted">${p.description || p.short || ""}</p>
-        ${p.url ? `<div style="margin-top:.5rem"><span class="badge">${p.external?'External':'More'}</span></div>` : ""}
-      </a>
-    </div>
-  `;
-  grid.appendChild(c);
-} else {
-  // standard card (no flip)
-  const a = document.createElement("a");
-  a.className = "card";
-  a.href = p.url || "#";
-  if (p.external){ a.target = "_blank"; a.rel = "noopener"; }
-  a.innerHTML = `
-    <span class="badge">${p.status}</span>
-    <h3>${p.title}</h3>
-    <div class="meta-row">
-      ${p.date ? `<time datetime="${p.date}">${fmt(p.date)}</time>` : ""}
-      ${p.tags.length ? `· ${p.tags.join(", ")}` : ""}
-    </div>
-    <p class="muted">${p.short}</p>
-  `;
-  grid.appendChild(a);
-}
+      if (p.cover) {
+        const wrapper = document.createElement('div');
+        wrapper.className = 'flip';
+        wrapper.innerHTML = `
+          <div class="flip-inner">
+            <a class="flip-face" href="${p.url || '#'}" ${p.external ? 'target="_blank" rel="noopener"' : ''}>
+              <img src="${p.cover}" alt="" style="width:100%;height:140px;object-fit:cover;border-radius:12px;margin-bottom:.6rem" />
+              <span class="badge">${p.status}</span>
+              <h3>${p.title}</h3>
+              <div class="meta-row">
+                ${p.date ? `<time datetime="${p.date}">${formatDate(p.date)}</time>` : ''}
+                ${p.tags.length ? `· ${p.tags.join(', ')}` : ''}
+              </div>
+              <p class="muted">${p.short}</p>
+            </a>
+            <a class="flip-back" href="${p.url || '#'}" ${p.external ? 'target="_blank" rel="noopener"' : ''}>
+              <h3>${p.title}</h3>
+              ${p.description ? `<p class="muted">${p.description}</p>` : ''}
+              ${p.url ? `<div style="margin-top:.65rem"><span class="badge">${p.external ? 'External' : 'Details'}</span></div>` : ''}
+            </a>
+          </div>
+        `;
+        grid.appendChild(wrapper);
+      } else {
+        const card = document.createElement('a');
+        card.className = 'card';
+        card.href = p.url || '#';
+        if (p.external) {
+          card.target = '_blank';
+          card.rel = 'noopener';
+        }
+        card.innerHTML = `
+          <span class="badge">${p.status}</span>
+          <h3>${p.title}</h3>
+          <div class="meta-row">
+            ${p.date ? `<time datetime="${p.date}">${formatDate(p.date)}</time>` : ''}
+            ${p.tags.length ? `· ${p.tags.join(', ')}` : ''}
+          </div>
+          ${p.short ? `<p class="muted">${p.short}</p>` : ''}
+        `;
+        grid.appendChild(card);
+      }
+    });
+  }
+
+  function slugify(value) {
+    return String(value || '')
+      .toLowerCase()
+      .trim()
+      .replace(/[^a-z0-9\s-]/g, '')
+      .replace(/\s+/g, '-')
+      .replace(/-+/g, '-');
+  }
+
+  function formatDate(value) {
+    try {
+      return new Date(value).toISOString().slice(0, 10);
+    } catch (err) {
+      return value;
+    }
+  }
+})();

--- a/projects.html
+++ b/projects.html
@@ -4,105 +4,61 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Projects — Michael C. Barros</title>
-  <meta name="description" content="Current work, collaborations, and research initiatives.">
+  <meta name="description" content="Current research, collaborations, and media experiments exploring myth and the sacred." />
   <link rel="stylesheet" href="./style.css" />
-
   <style>
-    /* Scoped, cooperative with style.css */
-    :root{ --ink:#111827; --muted:#6b7280; --ring:rgba(15,118,110,.25); }
-    .shell{max-width:1100px;margin:0 auto;padding:20px 20px 48px}
-    .site-header{display:flex;align-items:center;justify-content:space-between;padding:10px 0}
-    .brand{font-weight:700;text-decoration:none;color:var(--ink)}
-    .nav{display:flex;gap:18px;flex-wrap:wrap}
-    .nav a{color:var(--ink);text-decoration:none}
-    .nav a[aria-current="page"]{text-decoration:underline}
-    .nav a:hover{text-decoration:underline}
-
-    .hero--compact{padding:18px 0 6px}
-    .muted{color:var(--muted)}
-    .section-head{display:flex;align-items:baseline;justify-content:space-between;margin:0 0 .6rem}
-    .section-head h2{margin:0;font-size:1.25rem}
-
-    .toolbar{display:flex;gap:.6rem;flex-wrap:wrap;align-items:center;margin:.5rem 0 1rem}
-    .filters{display:flex;gap:.4rem;flex-wrap:wrap}
-    .filter-btn{padding:.35rem .6rem;border-radius:.6rem;border:1px solid #e5e7eb;background:#fff;cursor:pointer;font-size:.85rem}
-    .filter-btn.active{border-color:#0f766e;box-shadow:0 0 0 3px var(--ring)}
-    input[type="search"]{flex:1 1 280px;padding:.55rem .7rem;border:1px solid #e5e7eb;border-radius:.6rem}
-
-    .grid{display:grid;gap:16px}
-    @media(min-width:900px){.grid.cols-3{grid-template-columns:repeat(3,1fr)}.grid.cols-2{grid-template-columns:repeat(2,1fr)}}
-    .card{background:#fff;border:1px solid rgba(160,125,59,.25);border-radius:12px;padding:16px;transition:.2s;color:inherit;text-decoration:none;display:block}
-    .card:hover{border-color:rgba(160,125,59,.5);box-shadow:0 10px 26px rgba(0,0,0,.08);transform:translateY(-2px)}
-    .badge{display:inline-block;border:1px solid rgba(160,125,59,.35);color:var(--accent);font-family:'IBM Plex Mono',monospace;font-size:.72rem;padding:.15rem .45rem;border-radius:.4rem;margin-bottom:.35rem}
-
-    /* Flip cards */
-    .flip{perspective:1000px}
-    .flip-inner{position:relative;transform-style:preserve-3d;transition:transform .5s}
-    .flip:hover .flip-inner{transform:rotateY(180deg)}
-    .flip-face,.flip-back{backface-visibility:hidden;border-radius:12px;border:1px solid rgba(160,125,59,.25);padding:16px;background:#fff;height:100%}
-    .flip-back{position:absolute;inset:0;transform:rotateY(180deg)}
-    .meta-row{display:flex;gap:.5rem;align-items:center;flex-wrap:wrap;color:var(--muted);font-size:.85rem;margin:.25rem 0 .5rem}
-
-    .empty{padding:1rem;border:1px dashed #e5e7eb;border-radius:.75rem;background:#fafafa}
-
-    /* (Optional) Modal styles—kept for future detail view */
-    .modal{position:fixed;inset:0;background:rgba(0,0,0,.55);display:none}
-    .modal[aria-hidden="false"]{display:block}
-    .modal .inner{position:relative;max-width:900px;margin:4vh auto;background:#fff;border-radius:1rem;box-shadow:0 15px 35px rgba(0,0,0,.25);padding:1.25rem}
-    .modal .inner h1{margin:.4rem 0 0.35rem}
-    .modal .meta{color:var(--muted);font-size:.9rem}
-    .modal .divider{height:1px;background:#e5e7eb;margin:1rem 0}
-    .btn{display:inline-block;padding:.7rem 1.1rem;border-radius:.7rem;background:var(--ink);color:#fff;text-decoration:none;font-weight:700}
-    .btn:hover{filter:brightness(1.08)}
-    .btn.ghost{background:transparent;color:var(--ink);border:2px solid var(--ink)}
+    .filters-panel {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.8rem;
+      align-items: center;
+    }
+    .filters-panel input[type="search"] {
+      flex: 1 1 260px;
+      min-width: 220px;
+    }
   </style>
 </head>
-<body>
+<body class="page page--projects">
   <div class="shell">
-    <!-- Header -->
-    <header class="site-header">
+    <header class="site-header" aria-label="Site">
       <a class="brand" href="./index.html">Michael C. Barros</a>
-      <nav class="nav" aria-label="Main">
-        <a href="./about.html">About</a>
-        <a href="./books.html">Books</a>
-        <a id="nav-blog" href="https://mythonoesis.substack.com/" target="_blank" rel="noopener">Blog</a>
-        <a href="./projects.html" aria-current="page">Projects</a>
-        <a id="nav-research" href="#" target="_blank" rel="noopener">Research</a>
-        <a href="./contact.html">Contact</a>
+      <nav class="nav" aria-label="Primary">
+        <a class="nav__link" href="./about.html">About</a>
+        <a class="nav__link" href="./books.html">Books</a>
+        <a class="nav__link" id="nav-blog" href="https://mythonoesis.substack.com/" target="_blank" rel="noopener">Blog</a>
+        <a class="nav__link" href="./projects.html" aria-current="page">Projects</a>
+        <a class="nav__link" id="nav-research" href="#" target="_blank" rel="noopener">Research</a>
+        <a class="nav__link" href="./contact.html">Contact</a>
       </nav>
     </header>
 
-    <!-- Title -->
-    <section class="hero--compact">
-      <h1>Projects</h1>
-      <p class="muted">Active work, collaborations, and works-in-progress.</p>
-    </section>
+    <main>
+      <section class="page-header">
+        <span class="eyebrow">Projects</span>
+        <h1 class="page-title">Research constellations &amp; works-in-progress</h1>
+        <p class="page-kicker">Active collaborations, design experiments, and scholarly initiatives. Filter by status or search for a topic.</p>
+      </section>
 
-    <div class="divider"></div>
+      <section class="section-card" aria-labelledby="proj-heading">
+        <div class="section-heading">
+          <h2 id="proj-heading">Browse projects</h2>
+          <span class="muted small">Hover cards flip for deeper descriptions.</span>
+        </div>
+        <div class="filters-panel" role="group" aria-label="Filters">
+          <div id="filters" class="filters"></div>
+          <input id="search" type="search" placeholder="Search title, tags, or summary…" aria-label="Search projects" />
+        </div>
+        <div id="projects-grid" class="grid cols-3" style="margin-top: 2rem;"></div>
+        <div id="empty" class="empty" style="display: none; margin-top: 1.5rem;">No projects match your filters yet—adjust the search or status.</div>
+      </section>
+    </main>
 
-    <!-- Filters + search -->
-    <section aria-labelledby="proj-heading">
-      <div class="section-head">
-        <h2 id="proj-heading">Browse</h2>
-        <span class="muted" style="font-size:.95rem">Filter by status or type; hover cards flip for details</span>
-      </div>
-
-      <div class="toolbar">
-        <div id="filters" class="filters" role="group" aria-label="Filters"></div>
-        <input id="search" type="search" placeholder="Search title, tags, summary…" aria-label="Search projects">
-      </div>
-
-      <div id="projects-grid" class="grid cols-3"></div>
-      <div id="empty" class="empty" style="display:none">No projects match your filters.</div>
-    </section>
-
-    <footer class="footer" style="text-align:center;color:var(--muted);margin-top:32px;font-size:.95rem">
-      © <span id="year"></span> Michael C. Barros
-    </footer>
+    <footer>© <span id="year"></span> Michael C. Barros</footer>
   </div>
 
-  <!-- Data then behavior -->
   <script defer src="./js/data/data.js"></script>
+  <script defer src="./js/nav.js"></script>
   <script defer src="./js/projects.js"></script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -1,19 +1,28 @@
-/* ===============================
-   Base site variables
-=============================== */
+@import url('https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&family=Playfair+Display:wght@500;600&display=swap');
+
 :root {
-  --ink: #111827;
-  --muted: #6b7280;
-  --accent: #0f766e;
-  --paper: #f7f4ee;
-  --card: #ffffff;
-  --ring: rgba(15, 118, 110, 0.25);
-  --brand: #243a7e; /* deep blue accent for buttons/links */
+  --ink: #f5f6ff;
+  --muted: rgba(226, 232, 255, 0.72);
+  --accent: #c084fc;
+  --accent-strong: #a855f7;
+  --accent-soft: rgba(192, 132, 252, 0.35);
+  --paper: rgba(10, 13, 34, 0.85);
+  --paper-strong: rgba(14, 18, 46, 0.9);
+  --card: rgba(12, 16, 38, 0.76);
+  --card-soft: rgba(18, 24, 55, 0.65);
+  --border: rgba(162, 190, 255, 0.22);
+  --border-strong: rgba(224, 236, 255, 0.32);
+  --glow: rgba(160, 120, 255, 0.45);
+  --ring: rgba(160, 120, 255, 0.35);
+  --radius-lg: 24px;
+  --radius-md: 18px;
+  --radius-sm: 12px;
+  --shadow-soft: 0 25px 60px rgba(4, 6, 20, 0.45);
+  --shadow-card: 0 18px 40px rgba(6, 10, 32, 0.55);
+  --shadow-inner: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+  --header-blur: saturate(140%) blur(18px);
 }
 
-/* ===============================
-   Global defaults
-=============================== */
 *,
 *::before,
 *::after {
@@ -26,12 +35,76 @@ html {
 
 body {
   margin: 0;
+  font-family: 'Plus Jakarta Sans', 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
   font-size: 17px;
-  line-height: 1.75;
-  font-family: "EB Garamond", Georgia, serif;
-  background: var(--paper);
+  line-height: 1.7;
+  background: radial-gradient(circle at 20% -10%, rgba(93, 63, 211, 0.3), transparent 40%),
+    radial-gradient(circle at 80% 0%, rgba(15, 118, 110, 0.28), transparent 42%),
+    linear-gradient(180deg, #050310 0%, #0a0f25 36%, #04030d 100%);
   color: var(--ink);
+  min-height: 100vh;
   -webkit-font-smoothing: antialiased;
+  position: relative;
+  overflow-x: hidden;
+}
+
+body::before,
+body::after {
+  content: '';
+  position: fixed;
+  z-index: -2;
+  width: 420px;
+  height: 420px;
+  border-radius: 50%;
+  filter: blur(90px);
+  opacity: 0.55;
+  pointer-events: none;
+  transition: opacity 0.4s ease;
+}
+
+body::before {
+  top: -120px;
+  left: -140px;
+  background: radial-gradient(circle, rgba(86, 136, 255, 0.58), transparent 70%);
+  animation: drift 18s ease-in-out infinite;
+}
+
+body::after {
+  bottom: -120px;
+  right: -140px;
+  background: radial-gradient(circle, rgba(192, 132, 252, 0.65), transparent 70%);
+  animation: drift 26s ease-in-out infinite reverse;
+}
+
+@keyframes drift {
+  0%,
+  100% {
+    transform: translate3d(0, 0, 0) scale(1);
+  }
+  50% {
+    transform: translate3d(0, 18px, 0) scale(1.1);
+  }
+}
+
+.shell {
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: 32px 20px 80px;
+  position: relative;
+}
+
+@media (min-width: 1200px) {
+  .shell {
+    padding-left: 32px;
+    padding-right: 32px;
+  }
+}
+
+header,
+main,
+footer {
+  position: relative;
+  z-index: 1;
 }
 
 img {
@@ -39,403 +112,559 @@ img {
   display: block;
 }
 
-/* ===============================
-   Typography
-=============================== */
 h1,
 h2,
-h3 {
-  letter-spacing: -0.015em;
-  font-weight: 600;
-  margin-top: 0;
-  margin-bottom: 0.5em;
-  line-height: 1.25;
+h3,
+h4 {
+  font-family: 'Playfair Display', 'Times New Roman', serif;
+  letter-spacing: -0.01em;
+  margin: 0 0 0.55em;
+  color: var(--ink);
 }
 
 h1 {
-  font-size: 2.6rem;
+  font-size: clamp(2.6rem, 4vw, 3.6rem);
+  line-height: 1.08;
 }
+
 h2 {
-  font-size: 1.8rem;
-  margin-top: 1.5rem;
+  font-size: clamp(1.9rem, 3vw, 2.4rem);
 }
+
 h3 {
-  font-size: 1.35rem;
+  font-size: clamp(1.3rem, 2.2vw, 1.6rem);
 }
 
 p {
-  margin-top: 0;
-  margin-bottom: 1em;
+  margin: 0 0 1.1em;
+  color: var(--muted);
 }
 
-/* ===============================
-   Links
-=============================== */
 a {
-  position: relative;
-  color: var(--brand);
+  color: inherit;
   text-decoration: none;
+  position: relative;
 }
+
 a::after {
-  content: "";
+  content: '';
   position: absolute;
   left: 0;
-  bottom: -2px;
+  bottom: -3px;
   width: 100%;
   height: 1px;
   background: currentColor;
   transform: scaleX(0);
   transform-origin: left;
-  transition: transform 0.25s ease;
+  transition: transform 0.22s ease;
+  opacity: 0.8;
 }
+
 a:hover::after {
   transform: scaleX(1);
 }
 
-/* ===============================
-   Buttons
-=============================== */
-.btn {
-  display: inline-block;
-  padding: 0.7rem 1.1rem;
-  border-radius: 0.7rem;
-  background: var(--ink);
-  color: #fff;
-  font-weight: 700;
-  text-decoration: none;
-  position: relative;
-  overflow: hidden;
-  transition: background 0.2s ease, transform 0.15s ease;
+a.btn::after,
+a.brand::after,
+a.nav__link::after {
+  display: none;
 }
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  padding: 0.75rem 1.35rem;
+  border-radius: 999px;
+  font-weight: 600;
+  color: #070818;
+  background: linear-gradient(130deg, #fdf2ff 0%, #c084fc 50%, #38bdf8 100%);
+  box-shadow: 0 8px 26px rgba(110, 149, 255, 0.35);
+  transition: transform 0.18s ease, box-shadow 0.22s ease;
+}
+
 .btn:hover {
   transform: translateY(-2px);
-  filter: brightness(1.08);
+  box-shadow: 0 15px 36px rgba(116, 181, 255, 0.45);
 }
-.btn:focus {
+
+.btn:focus-visible {
   outline: none;
-  box-shadow: 0 0 0 3px rgba(36, 58, 126, 0.35);
+  box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.35);
 }
+
 .btn.ghost {
   background: transparent;
-  border: 2px solid var(--brand);
-  color: var(--brand);
+  color: var(--ink);
+  border: 1px solid var(--border-strong);
+  box-shadow: none;
+  backdrop-filter: blur(16px);
 }
+
 .btn.ghost:hover {
-  background: rgba(36, 58, 126, 0.08);
+  color: #fdf2ff;
+  background: rgba(156, 163, 255, 0.18);
+  border-color: rgba(255, 255, 255, 0.4);
 }
 
-/* ===============================
-   Layout utilities
-=============================== */
-.shell {
-  max-width: 1060px;
-  margin: 0 auto;
-  padding: 20px 20px 48px;
-}
-.divider {
-  height: 1px;
-  background: #e5e7eb;
-  margin: 28px 0;
+.cta-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.9rem;
 }
 
-/* ===============================
-   Header & Nav
-=============================== */
-.site-header {
+.small {
+  font-size: 0.85rem;
+}
+
+.muted {
+  color: var(--muted);
+}
+
+.eyebrow {
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: rgba(226, 232, 255, 0.68);
+}
+
+.section-heading {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 10px 0;
+  gap: 1rem;
+  margin-bottom: 1.6rem;
 }
+
+.section-heading h2 {
+  margin: 0;
+}
+
+.section-heading .link {
+  font-weight: 600;
+  color: var(--ink);
+  opacity: 0.8;
+}
+
+.section-heading .link:hover {
+  opacity: 1;
+}
+
+.divider {
+  width: 100%;
+  height: 1px;
+  margin: 40px 0;
+  background: linear-gradient(90deg, transparent, rgba(206, 217, 255, 0.35), transparent);
+  border: none;
+}
+
+.site-header {
+  position: sticky;
+  top: 16px;
+  z-index: 20;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.6rem;
+  padding: 16px 22px;
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(174, 196, 255, 0.15);
+  background: rgba(10, 12, 30, 0.75);
+  box-shadow: 0 25px 45px rgba(4, 6, 20, 0.35);
+  backdrop-filter: var(--header-blur);
+}
+
 .brand {
-  font-weight: 700;
-  text-decoration: none;
+  font-family: 'Playfair Display', 'Times New Roman', serif;
+  font-size: 1.2rem;
+  font-weight: 600;
   color: var(--ink);
 }
+
 .nav {
   display: flex;
-  gap: 18px;
   flex-wrap: wrap;
-}
-.nav a {
-  color: var(--ink);
-  text-decoration: none;
-}
-.nav a:hover {
-  text-decoration: underline;
+  gap: 0.85rem;
 }
 
-/* ===============================
-   Hero
-=============================== */
-.hero {
-  text-align: center;
-  padding: 60px 0 24px;
-  background: linear-gradient(180deg, #fdfcf9 0%, transparent 90%);
-}
-.hero h1 {
-  font-size: clamp(2rem, 4vw, 3rem);
-  margin-bottom: 0.5rem;
-}
-.hero p {
-  font-size: 1.1rem;
-  max-width: 720px;
-  margin: 0.5rem auto 1rem;
+.nav__link {
+  padding: 0.35rem 0.65rem;
+  border-radius: 999px;
   color: var(--muted);
-}
-.cta-row {
-  display: flex;
-  gap: 0.75rem;
-  justify-content: center;
-  flex-wrap: wrap;
-  margin-top: 14px;
+  font-weight: 500;
+  transition: color 0.18s ease, background 0.18s ease;
 }
 
-/* ===============================
-   Cards
-=============================== */
+.nav__link[aria-current='page'] {
+  color: #f5f3ff;
+  background: rgba(192, 132, 252, 0.16);
+}
+
+.nav__link:hover {
+  color: #f8f7ff;
+  background: rgba(192, 132, 252, 0.12);
+}
+
+@media (max-width: 720px) {
+  .site-header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .nav {
+    justify-content: center;
+  }
+}
+
+.hero {
+  position: relative;
+  margin-top: 72px;
+  display: grid;
+  gap: 3rem;
+  align-items: center;
+}
+
+@media (min-width: 960px) {
+  .hero {
+    grid-template-columns: minmax(0, 1.15fr) minmax(220px, 0.85fr);
+  }
+}
+
+.hero__content h1 {
+  background: linear-gradient(120deg, #ffffff 0%, #dfe4ff 45%, #a855f7 90%);
+  -webkit-background-clip: text;
+  color: transparent;
+}
+
+.hero__tagline {
+  font-size: 1.2rem;
+  max-width: 620px;
+}
+
+.hero__meta {
+  margin-top: 1.4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+}
+
+.hero__meta .badge-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  font-size: 0.85rem;
+  color: rgba(226, 232, 255, 0.65);
+}
+
+.hero__media {
+  position: relative;
+  width: min(360px, 100%);
+  justify-self: center;
+}
+
+.hero__orb {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 1;
+  border-radius: 50%;
+  background: radial-gradient(circle at 25% 25%, rgba(255, 255, 255, 0.95), rgba(192, 132, 252, 0.75) 45%, rgba(79, 70, 229, 0.8) 100%);
+  box-shadow: var(--shadow-soft);
+  overflow: hidden;
+}
+
+.hero__orb::after {
+  content: '';
+  position: absolute;
+  inset: 18%;
+  border-radius: 50%;
+  background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.4), transparent 70%);
+  filter: blur(12px);
+}
+
+.hero__glyph {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  font-size: clamp(2rem, 7vw, 3.6rem);
+  color: rgba(8, 12, 38, 0.82);
+  font-family: 'Playfair Display', serif;
+  letter-spacing: 0.08em;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.3rem 0.85rem;
+  border-radius: 999px;
+  font-size: 0.76rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  border: 1px solid var(--border);
+  background: rgba(12, 17, 42, 0.65);
+  color: rgba(225, 232, 255, 0.75);
+}
+
 .grid {
   display: grid;
-  gap: 16px;
-}
-@media (min-width: 900px) {
-  .grid.cols-3 {
-    grid-template-columns: repeat(3, 1fr);
-  }
-  .grid.cols-2 {
-    grid-template-columns: repeat(2, 1fr);
-  }
-}
-.card {
-  background: var(--card);
-  border: 1px solid rgba(160, 125, 59, 0.25);
-  border-radius: 12px;
-  padding: 16px;
-  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
-  color: inherit;
-  text-decoration: none;
-  display: block;
-}
-.card:hover {
-  transform: translateY(-4px);
-  border-color: var(--brand);
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
-}
-.badge {
-  display: inline-block;
-  border: 1px solid rgba(160, 125, 59, 0.35);
-  color: var(--accent);
-  font-family: "IBM Plex Mono", monospace;
-  font-size: 0.72rem;
-  padding: 0.15rem 0.45rem;
-  border-radius: 0.4rem;
-  margin-bottom: 0.35rem;
+  gap: 22px;
 }
 
-/* ===============================
-   Flip cards
-=============================== */
-.flip {
-  perspective: 1000px;
+@media (min-width: 900px) {
+  .grid.cols-3 {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+  .grid.cols-2 {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
 }
+
+.card,
+.flip-face,
+.flip-back,
+.feature-box,
+.section-card,
+.info-card {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 1.35rem;
+  box-shadow: var(--shadow-card);
+  backdrop-filter: blur(18px);
+  color: var(--ink);
+  transition: transform 0.22s ease, border-color 0.22s ease, box-shadow 0.22s ease;
+}
+
+.card:hover,
+.flip:hover .flip-face,
+.flip:hover .flip-back,
+.feature-box:hover,
+.section-card:hover,
+.info-card:hover {
+  border-color: rgba(255, 255, 255, 0.35);
+  transform: translateY(-3px);
+  box-shadow: 0 28px 60px rgba(9, 13, 34, 0.6);
+}
+
+.card h3 {
+  margin-top: 0.25rem;
+  margin-bottom: 0.4rem;
+}
+
+.feature-grid {
+  display: grid;
+  gap: 1.8rem;
+}
+
+@media (min-width: 960px) {
+  .feature-grid.two-col {
+    grid-template-columns: minmax(0, 360px) minmax(0, 1fr);
+  }
+}
+
+.feature-media {
+  position: relative;
+}
+
+.feature-media img {
+  border-radius: var(--radius-md);
+  box-shadow: 0 22px 48px rgba(8, 10, 32, 0.58);
+}
+
+.feature-media--avatar {
+  width: min(260px, 100%);
+  aspect-ratio: 1;
+  border-radius: 50%;
+  background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.9), rgba(192, 132, 252, 0.55) 60%, rgba(79, 70, 229, 0.78));
+  box-shadow: 0 28px 60px rgba(7, 10, 32, 0.65);
+  overflow: hidden;
+}
+
+.feature-media--avatar::after {
+  content: '';
+  position: absolute;
+  inset: 18%;
+  border-radius: 50%;
+  background: radial-gradient(circle at 40% 40%, rgba(255, 255, 255, 0.4), transparent 70%);
+  filter: blur(12px);
+}
+
+.feature-body,
+.feature-copy,
+.book-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+
+.book-cover {
+  width: 100%;
+  border-radius: var(--radius-md);
+  box-shadow: 0 25px 50px rgba(8, 10, 32, 0.65);
+}
+
+.book-copy .book-desc p {
+  margin-bottom: 0.85rem;
+  color: var(--muted);
+}
+
+.flip {
+  perspective: 1400px;
+}
+
 .flip-inner {
   position: relative;
   transform-style: preserve-3d;
-  transition: transform 0.5s;
+  transition: transform 0.55s ease;
+  min-height: 220px;
 }
+
 .flip:hover .flip-inner {
   transform: rotateY(180deg);
 }
+
 .flip-face,
 .flip-back {
   backface-visibility: hidden;
-  border-radius: 12px;
-  border: 1px solid rgba(160, 125, 59, 0.25);
-  padding: 16px;
-  background: #fff;
-  height: 100%;
-}
-.flip-back {
   position: absolute;
   inset: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+
+.flip-back {
   transform: rotateY(180deg);
 }
 
-/* ===============================
-   Filters / chips
-=============================== */
-.chip {
-  display: inline-block;
-  padding: 0.35rem 0.6rem;
-  border-radius: 0.6rem;
-  border: 1px solid #e5e7eb;
-  background: #fff;
-  cursor: pointer;
-  font-size: 0.85rem;
-  transition: background 0.2s, color 0.2s, transform 0.15s;
+.empty {
+  border-radius: var(--radius-md);
+  border: 1px dashed rgba(198, 205, 255, 0.35);
+  padding: 1.2rem;
+  text-align: center;
+  background: rgba(12, 15, 32, 0.68);
+  color: var(--muted);
 }
-.chip:hover {
+
+footer {
+  margin-top: 72px;
+  text-align: center;
+  color: rgba(214, 222, 255, 0.65);
+  font-size: 0.95rem;
+}
+
+code {
+  font-family: 'Fira Code', 'SFMono-Regular', Consolas, 'Liberation Mono', monospace;
+  font-size: 0.9rem;
+  color: #e9edff;
+  background: rgba(17, 20, 42, 0.9);
+  border: 1px solid rgba(162, 190, 255, 0.3);
+  padding: 0.25rem 0.45rem;
+  border-radius: 8px;
+}
+
+input[type='search'],
+input[type='text'],
+button {
+  font: inherit;
+}
+
+input[type='search'],
+textarea {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(176, 197, 255, 0.35);
+  background: rgba(8, 10, 24, 0.6);
+  color: var(--ink);
+  box-shadow: var(--shadow-inner);
+}
+
+input[type='search']:focus,
+textarea:focus {
+  outline: none;
+  border-color: rgba(192, 132, 252, 0.65);
+  box-shadow: 0 0 0 3px rgba(192, 132, 252, 0.24);
+}
+
+.filter-btn {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  border: 1px solid rgba(180, 200, 255, 0.3);
+  background: rgba(10, 12, 30, 0.6);
+  color: rgba(222, 230, 255, 0.8);
+  cursor: pointer;
+  transition: transform 0.18s ease, border-color 0.18s ease, background 0.18s ease;
+}
+
+.filter-btn:hover {
+  border-color: rgba(255, 255, 255, 0.4);
   transform: translateY(-2px);
 }
-.chip.active {
-  background: var(--brand);
+
+.filter-btn.active {
+  background: rgba(192, 132, 252, 0.22);
+  border-color: rgba(192, 132, 252, 0.4);
   color: #fff;
-  border-color: var(--brand);
+  box-shadow: 0 10px 24px rgba(192, 132, 252, 0.25);
 }
 
-/* ===============================
-   Book hero
-=============================== */
-.book-hero {
-  display: grid;
-  gap: 18px;
-  align-items: center;
+.page-header {
+  margin-top: 72px;
+  margin-bottom: 36px;
 }
-@media (min-width: 900px) {
-  .book-hero {
-    grid-template-columns: 160px 1fr;
+
+.page-header .page-title {
+  font-size: clamp(2rem, 4vw, 3rem);
+  background: linear-gradient(120deg, #ffffff 0%, #dfe4ff 45%, #a855f7 90%);
+  -webkit-background-clip: text;
+  color: transparent;
+}
+
+.page-header .page-kicker {
+  font-size: 1.05rem;
+  max-width: 720px;
+}
+
+.detail-grid {
+  display: grid;
+  gap: 24px;
+}
+
+@media (min-width: 960px) {
+  .detail-grid.two-col {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
-.book-cover {
-  width: 100%;
-  height: auto;
-  border-radius: 8px;
-  box-shadow: 0 8px 22px rgba(0, 0, 0, 0.08);
-}
 
-/* ===============================
-   Reviews
-=============================== */
-.reviews {
-  display: grid;
-  gap: 12px;
-}
-@media (min-width: 900px) {
-  .reviews {
-    grid-template-columns: repeat(3, 1fr);
-  }
-}
-.review {
-  background: #fff;
-  border: 1px solid rgba(160, 125, 59, 0.25);
-  border-radius: 10px;
-  padding: 12px;
-}
-.review small {
-  color: var(--muted);
-}
-
-/* ===============================
-   Modal
-=============================== */
-.modal {
-  background: rgba(0, 0, 0, 0.6);
+.info-card {
   display: flex;
-  justify-content: center;
-  align-items: flex-start;
-  padding: 4vh 1rem;
-  opacity: 0;
-  pointer-events: none;
-  transition: opacity 0.25s ease;
+  flex-direction: column;
+  gap: 0.75rem;
 }
-.modal.open {
-  opacity: 1;
-  pointer-events: auto;
+
+.meta-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem 0.8rem;
+  font-size: 0.85rem;
+  color: rgba(212, 220, 255, 0.68);
 }
-.modal .inner {
-  background: #fff;
-  border-radius: 1rem;
-  max-width: 880px;
-  padding: 2rem;
-  box-shadow: 0 20px 45px rgba(0, 0, 0, 0.35);
-  animation: zoomIn 0.25s ease;
+
+address {
+  font-style: normal;
 }
-@keyframes zoomIn {
-  from {
-    transform: scale(0.92) translateY(20px);
-    opacity: 0;
-  }
-  to {
-    transform: scale(1) translateY(0);
-    opacity: 1;
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+    scroll-behavior: auto !important;
   }
 }
-
-/* ===============================
-   Footer
-=============================== */
-.footer {
-  padding: 32px 0;
-  text-align: center;
-  font-family: "IBM Plex Mono", monospace;
-  font-size: 0.9rem;
-  color: var(--muted);
-  border-top: 1px solid rgba(0, 0, 0, 0.08);
-}
-/* ===== Jump Kit: layout + components ===== */
-
-/* Palette tune */
-:root{
-  --brand:#0f766e;           /* accent */
-  --ink:#121212;
-  --muted:#6b7280;
-  --paper:#F7F4EE;
-  --card:#ffffff;
-  --ring:rgba(15,118,110,.25);
-}
-
-/* Container */
-.shell{max-width:1160px;margin:0 auto;padding:24px 20px 56px}
-
-/* Sticky clean header */
-.site-header{position:sticky;top:0;background:var(--paper);z-index:50;
-  display:flex;align-items:center;justify-content:space-between;padding:10px 0;
-  border-bottom:1px solid rgba(0,0,0,.06);backdrop-filter:saturate(1.2) blur(4px)}
-.brand{font-weight:800;letter-spacing:-.01em}
-.nav{display:flex;gap:20px}
-.nav a{color:var(--ink);text-decoration:none}
-.nav a:hover{text-decoration:underline}
-
-/* Big hero, darker weight like JP */
-.hero{padding:56px 0 28px;text-align:center;background:
-  radial-gradient(1200px 400px at 50% -100px, #ffffff 0%, transparent 70%)}
-.hero h1{font-size:clamp(2.2rem,4vw,3rem);letter-spacing:-.015em}
-.hero .tagline{color:var(--muted);font-size:1.08rem}
-
-/* Buttons – slightly chunkier */
-.btn{display:inline-block;padding:.78rem 1.15rem;border-radius:.8rem;
-  background:var(--ink);color:#fff;text-decoration:none;font-weight:700;
-  transition:transform .15s ease, box-shadow .15s ease}
-.btn:hover{transform:translateY(-2px);box-shadow:0 8px 18px rgba(0,0,0,.12)}
-.btn.ghost{background:transparent;color:var(--ink);border:2px solid var(--ink)}
-.btn.ghost:hover{background:rgba(0,0,0,.04)}
-
-/* Section header */
-.section-head{display:flex;align-items:baseline;justify-content:space-between;margin:0 0 12px}
-.section-head h2{margin:0;font-size:1.35rem}
-
-/* Feature box (book hero card) */
-.feature-box{background:var(--card);border:1px solid rgba(0,0,0,.08);border-radius:14px;
-  box-shadow:0 10px 28px rgba(0,0,0,.08);padding:18px}
-.feature-grid{display:grid;gap:20px;align-items:stretch}
-@media(min-width:980px){.feature-grid{grid-template-columns:minmax(280px,360px) 1fr}}
-.feature-media{border-radius:12px;overflow:hidden;box-shadow:0 10px 28px rgba(0,0,0,.10)}
-.feature-media img{display:block;width:100%;height:100%;object-fit:cover}
-.feature-body h3{margin:.2rem 0 .4rem;font-size:1.6rem}
-.feature-body .muted{margin:.4rem 0 .6rem;color:var(--muted)}
-.feature-body .cta-row{justify-content:flex-start;margin:.6rem 0 .4rem}
-.feature-body .desc{margin-top:.4rem}
-.feature-body .desc p{margin:.58rem 0;line-height:1.72}
-
-/* Card grid (projects) */
-.grid{display:grid;gap:16px}
-@media(min-width:900px){.grid.cols-3{grid-template-columns:repeat(3,1fr)}}
-.card{background:#fff;border:1px solid rgba(0,0,0,.08);border-radius:12px;padding:16px;
-  transition:transform .15s ease, box-shadow .15s ease, border-color .15s ease}
-.card:hover{transform:translateY(-2px);box-shadow:0 10px 24px rgba(0,0,0,.10);border-color:rgba(0,0,0,.18)}
-.badge{display:inline-block;border:1px solid rgba(15,118,110,.35);color:var(--brand);
-  font-family:ui-monospace, SFMono-Regular, Menlo, monospace;font-size:.72rem;padding:.18rem .46rem;border-radius:.5rem}
-
-/* Divider + footer */
-.divider{height:1px;background:#e5e7eb;margin:28px 0}
-.footer{padding:36px 0;text-align:center;color:var(--muted);font-size:.95rem}


### PR DESCRIPTION
## Summary
- Reimagine the shared visual system with an ethereal gradient palette, glassmorphism cards, and refreshed typography across the site.
- Rebuild the home page hero, featured book, Substack, and bio sections to feel more dynamic while remaining data-driven.
- Update the About, Books, Projects, and Contact pages with consistent layouts, abstract portrait treatments, and richer interactions (filters, DOM-ready scripts).
- Replace the nav helper with a true JS module and streamline the projects renderer for cleaner filtering and flip-card handling.

## Testing
- Manual smoke-test in local browser

------
https://chatgpt.com/codex/tasks/task_e_68e2ec863e888330a54c69015715c046