### PR TITLE
Refine scholarly theme and copy

### DIFF
--- a/about.html
+++ b/about.html
@@ -4,155 +4,238 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>About — Michael C. Barros</title>
-
+  <meta name="description" content="Research overview for Michael C. Barros, scholar of religion and popular culture focusing on sacred imagination in media." />
   <link rel="stylesheet" href="./style.css" />
   <style>
-    /* Page-scoped polish for About */
-    :root{ --ink:#111827; --muted:#6b7280; --ring:rgba(15,118,110,.25); }
-    .shell{max-width:1160px;margin:0 auto;padding:24px 20px 56px}
-
-    /* Hero block */
-    .about-hero{
-      display:grid; gap:18px; align-items:end; margin:8px 0 18px;
+    .about-hero {
+      display: grid;
+      gap: 2rem;
     }
-    @media (min-width:980px){
-      .about-hero{ grid-template-columns: minmax(260px, 360px) 1fr; }
+    @media (min-width: 960px) {
+      .about-hero {
+        grid-template-columns: minmax(0, 360px) minmax(0, 1fr);
+      }
     }
-    .about-title h1{
-      margin:0; font-size:clamp(2rem, 4.2vw, 3.2rem); letter-spacing:-.015em;
-      line-height:1.05;
+    .about-list {
+      display: grid;
+      gap: 1.4rem;
     }
-    .about-kicker{
-      color:var(--muted);
-      font-weight:600;
-      line-height:1.25;
-      white-space:pre-line;               /* keeps the stacked lines look */
+    @media (min-width: 880px) {
+      .about-list {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
     }
-
-    /* Summary paragraph */
-    .lede{font-size:1.05rem; line-height:1.8; color:var(--ink); margin-top:8px}
-
-    /* Quick actions */
-    .cta-row{display:flex; gap:.6rem; flex-wrap:wrap; margin:14px 0 2px}
-    .btn{display:inline-block;padding:.7rem 1.1rem;border-radius:.8rem;background:#111827;color:#fff;
-      text-decoration:none;font-weight:700;transition:transform .15s ease, box-shadow .15s ease}
-    .btn:hover{transform:translateY(-2px);box-shadow:0 8px 18px rgba(0,0,0,.12)}
-    .btn.ghost{background:transparent;color:#111827;border:2px solid #111827}
-
-    /* Section headings */
-    .section{margin:26px 0}
-    .section h2{font-size:1.6rem; margin:.2rem 0 .6rem}
-
-    /* Two-column details list */
-    .cols{display:grid; gap:14px}
-    @media(min-width:980px){ .cols{grid-template-columns:1fr 1fr} }
-    .card{background:#fff;border:1px solid rgba(0,0,0,.08);border-radius:12px;padding:16px}
-
-    .muted{color:var(--muted)}
-    .divider{height:1px;background:#e5e7eb;margin:24px 0}
-    .footer{padding:36px 0;text-align:center;color:var(--muted);font-size:.95rem}
+    ul.about-items {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+      display: grid;
+      gap: 0.85rem;
+    }
+    ul.about-items li {
+      display: grid;
+      grid-template-columns: 26px 1fr;
+      align-items: start;
+      column-gap: 0.8rem;
+      line-height: 1.6;
+    }
+    .about-icon {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 26px;
+      height: 26px;
+    }
+    .about-icon svg {
+      width: 100%;
+      height: 100%;
+      stroke: var(--highlight);
+      stroke-width: 1.5;
+      fill: none;
+      opacity: 0.8;
+    }
+    .about-icon svg .fill {
+      fill: var(--highlight);
+      stroke: none;
+      opacity: 0.65;
+    }
+    .page--about .info-card {
+      padding: 1.6rem;
+    }
   </style>
 </head>
-<body>
+<body class="page page--about">
   <div class="shell">
-    <!-- Header -->
-    <header class="site-header">
+    <header class="site-header" aria-label="Site">
       <a class="brand" href="./index.html">Michael C. Barros</a>
-      <nav class="nav" aria-label="Main">
-        <a href="./about.html" aria-current="page">About</a>
-        <a href="./books.html">Books</a>
-        <a id="nav-blog" href="#" target="_blank" rel="noopener">Blog</a>
-        <a href="./projects.html">Projects</a>
-        <a id="nav-research" href="#" target="_blank" rel="noopener">Research</a>
-        <a href="./contact.html">Contact</a>
+      <nav class="nav" aria-label="Primary">
+        <a class="nav__link" href="./about.html" aria-current="page">About</a>
+        <a class="nav__link" href="./books.html">Books</a>
+        <a class="nav__link" id="nav-blog" href="#" target="_blank" rel="noopener">Blog</a>
+        <a class="nav__link" href="./projects.html">Projects</a>
+        <a class="nav__link" id="nav-research" href="#" target="_blank" rel="noopener">Research</a>
+        <a class="nav__link" href="./contact.html">Contact</a>
       </nav>
     </header>
 
-    <!-- Hero -->
-    <section class="about-hero">
-      <div class="about-title">
-        <h1>About</h1>
-        <div class="about-kicker">Scholar of
-religion &amp;
-popular
-culture</div>
-      </div>
-
-      <div>
-        <p class="lede">
-          Michael C. Barros studies how games, film, and speculative fiction become sites of religious
-          experience, symbolic imagination, and encounters with the sacred. His work draws on theology,
-          cultural history, and media analysis.
-        </p>
-
+    <main>
+      <section class="page-header">
+        <span class="eyebrow">About</span>
+        <h1 class="page-title">Research Overview</h1>
+        <p class="page-kicker">Scholarship that charts how sacred imagination moves through contemporary media cultures.</p>
         <div class="cta-row" role="group" aria-label="Primary actions">
           <a class="btn" href="./books.html">Books</a>
-          <a class="btn ghost" href="./projects.html">Projects</a>
-          <a class="btn ghost" href="./contact.html">Curriculum Vitae</a>
+          <a class="btn" href="./projects.html">Projects</a>
+          <a class="btn" href="./contact.html">Curriculum Vitae</a>
         </div>
-      </div>
-    </section>
+      </section>
 
-    <div class="divider" role="presentation"></div>
+      <section class="section-card">
+        <div class="about-hero">
+          <div class="feature-media feature-media--avatar" role="img" aria-label="Abstract portrait of Michael C. Barros"></div>
+          <div class="feature-body">
+            <h2>Research Overview</h2>
+            <p>Michael C. Barros studies how myth, ritual, and sacred imagination manifest in contemporary media. His work examines games, film, and speculative fiction as sites of religious experience and cultural formation, drawing on theology, cultural history, and media analysis to surface hidden architectures of meaning.</p>
+            <p>He develops frameworks that help players, readers, and viewers recognize the sacred textures embedded in contemporary storytelling, offering tools for scholarship, pedagogy, and practice.</p>
+          </div>
+        </div>
+      </section>
 
-    <!-- Affiliations & Focus -->
-    <section class="section">
-      <h2>Affiliations &amp; Focus</h2>
-      <div class="cols">
-        <div class="card">
-          <h3 style="margin:.1rem 0 .35rem">Areas</h3>
-          <ul class="muted" style="margin:.4rem 0 0; padding-left:1.1rem">
-            <li>Religion &amp; popular culture</li>
-            <li>Myth, ritual, and symbolic imagination</li>
-            <li>Games &amp; interactive media</li>
-            <li>Film and speculative fiction</li>
-          </ul>
-        </div>
-        <div class="card">
-          <h3 style="margin:.1rem 0 .35rem">Methods</h3>
-          <ul class="muted" style="margin:.4rem 0 0; padding-left:1.1rem">
-            <li>Theology &amp; religious studies</li>
-            <li>Media analysis &amp; cultural history</li>
-            <li>Reception &amp; adaptation studies</li>
-          </ul>
-        </div>
-      </div>
-    </section>
+      <div class="divider" role="presentation"></div>
 
-    <!-- Recent & Links -->
-    <section class="section">
-      <h2>Selected Links</h2>
-      <div class="cols">
-        <div class="card">
-          <h3 style="margin:.1rem 0 .35rem">Research profile</h3>
-          <p class="muted" style="margin:.35rem 0 .6rem">
-            External publications, preprints, and works-in-progress.
-          </p>
-          <a class="btn" id="about-research" href="#" target="_blank" rel="noopener">Open ResearchGate</a>
+      <section>
+        <div class="section-heading">
+          <h2>Focus &amp; affiliations</h2>
         </div>
-        <div class="card">
-          <h3 style="margin:.1rem 0 .35rem">Substack</h3>
-          <p class="muted" style="margin:.35rem 0 .6rem">
-            Short-form writing, notes, and ongoing conversations.
-          </p>
-          <a class="btn ghost" id="about-blog" href="#" target="_blank" rel="noopener">Visit Substack</a>
+        <div class="about-list">
+          <article class="info-card">
+            <h3>Areas of inquiry</h3>
+            <ul class="about-items">
+              <li>
+                <span class="about-icon" aria-hidden="true">
+                  <svg viewBox="0 0 24 24">
+                    <path d="M12 4v16M4 12h16" />
+                  </svg>
+                </span>
+                <span>Religion &amp; popular culture</span>
+              </li>
+              <li>
+                <span class="about-icon" aria-hidden="true">
+                  <svg viewBox="0 0 24 24">
+                    <path d="M5 19l14-14" />
+                    <path d="M9 5h10" />
+                    <path d="M5 19l4-.5L6.5 14" />
+                  </svg>
+                </span>
+                <span>Myth, ritual, and symbolic imagination</span>
+              </li>
+              <li>
+                <span class="about-icon" aria-hidden="true">
+                  <svg viewBox="0 0 24 24">
+                    <path d="M4 15c0-2.8 2-5 5-5h6c3 0 5 2.2 5 5" />
+                    <path d="M9 10V9a3 3 0 016 0v1" />
+                    <circle class="fill" cx="9" cy="15" r="1.4" />
+                    <circle class="fill" cx="15" cy="15" r="1.4" />
+                  </svg>
+                </span>
+                <span>Games &amp; interactive media</span>
+              </li>
+              <li>
+                <span class="about-icon" aria-hidden="true">
+                  <svg viewBox="0 0 24 24">
+                    <rect x="5" y="6" width="14" height="12" rx="1.5" />
+                    <circle class="fill" cx="8" cy="12" r="1.2" />
+                    <circle class="fill" cx="16" cy="12" r="1.2" />
+                  </svg>
+                </span>
+                <span>Film and speculative fiction</span>
+              </li>
+            </ul>
+          </article>
+          <article class="info-card">
+            <h3>Approaches</h3>
+            <ul class="about-items">
+              <li>
+                <span class="about-icon" aria-hidden="true">
+                  <svg viewBox="0 0 24 24">
+                    <circle cx="12" cy="12" r="7.5" />
+                    <path d="M12 6v12M6 12h12" />
+                  </svg>
+                </span>
+                <span>Theology &amp; religious studies</span>
+              </li>
+              <li>
+                <span class="about-icon" aria-hidden="true">
+                  <svg viewBox="0 0 24 24">
+                    <path d="M5 6h14v12H5z" />
+                    <path d="M5 10h14M9 6v12" />
+                  </svg>
+                </span>
+                <span>Media analysis &amp; cultural history</span>
+              </li>
+              <li>
+                <span class="about-icon" aria-hidden="true">
+                  <svg viewBox="0 0 24 24">
+                    <circle cx="7" cy="12" r="2.2" />
+                    <circle cx="17" cy="8" r="2.2" />
+                    <circle cx="17" cy="16" r="2.2" />
+                    <path d="M9 11l6-2M9 13l6 2" />
+                  </svg>
+                </span>
+                <span>Reception &amp; adaptation studies</span>
+              </li>
+              <li>
+                <span class="about-icon" aria-hidden="true">
+                  <svg viewBox="0 0 24 24">
+                    <path d="M4 15c1.5-1.5 3.5-1.5 5 0s3.5 1.5 5 0 3.5-1.5 5 0" />
+                    <path d="M4 9c1.5 1.5 3.5 1.5 5 0s3.5-1.5 5 0 3.5 1.5 5 0" />
+                  </svg>
+                </span>
+                <span>Ethnography of fandom &amp; play</span>
+              </li>
+            </ul>
+          </article>
         </div>
-      </div>
-    </section>
+      </section>
 
-    <footer class="footer">© <span id="year"></span> Michael C. Barros</footer>
+      <div class="divider" role="presentation"></div>
+
+      <section>
+        <div class="section-heading">
+          <h2>Connect</h2>
+        </div>
+        <div class="detail-grid two-col">
+          <article class="info-card">
+            <h3>Research profiles</h3>
+            <p>External publications, preprints, and works-in-progress.</p>
+            <a class="btn" id="about-research" href="#" target="_blank" rel="noopener">Open Research</a>
+          </article>
+          <article class="info-card">
+            <h3>Substack</h3>
+            <p>Short-form writing, field notes, and ongoing conversations.</p>
+            <a class="btn ghost" id="about-blog" href="#" target="_blank" rel="noopener">Visit Substack</a>
+          </article>
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      <p class="footer-tagline">Myth · Media · Imagination</p>
+      © <span id="year"></span> Michael C. Barros
+    </footer>
   </div>
 
-  <!-- Shared data + nav injection -->
   <script defer src="./js/data/data.js"></script>
   <script defer src="./js/nav.js"></script>
   <script>
-    // Page-local hookups
     window.addEventListener('DOMContentLoaded', () => {
       const links = (window.SITE_DATA && window.SITE_DATA.links) || window.LINKS || {};
-      document.getElementById('about-research').href = links.research || 'https://www.researchgate.net/';
-      document.getElementById('about-blog').href = links.blog || 'https://mythonoesis.substack.com/';
-      document.getElementById('year').textContent = new Date().getFullYear();
+      const research = document.getElementById('about-research');
+      if (research) research.href = links.research || 'https://www.researchgate.net/';
+      const blog = document.getElementById('about-blog');
+      if (blog) blog.href = links.blog || 'https://mythonoesis.substack.com/';
+      const year = document.getElementById('year');
+      if (year) year.textContent = new Date().getFullYear();
     });
   </script>
 </body>

--- a/books.html
+++ b/books.html
@@ -4,180 +4,193 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Books — Michael C. Barros</title>
-
+  <meta name="description" content="Books and forthcoming work on religion, myth, and popular culture by Michael C. Barros." />
   <link rel="stylesheet" href="./style.css" />
   <style>
-    :root{ --ink:#111827; --muted:#6b7280; --ring:rgba(15,118,110,.25); }
-    .shell{max-width:1100px;margin:0 auto;padding:20px 20px 48px}
-    .site-header{display:flex;align-items:center;justify-content:space-between;padding:10px 0}
-    .brand{font-weight:700;text-decoration:none;color:var(--ink)}
-    .nav{display:flex;gap:18px;flex-wrap:wrap}
-    .nav a{color:var(--ink);text-decoration:none}
-    .nav a:hover{text-decoration:underline}
-
-    .page-title{font-size:2.25rem;margin:0 0 .35rem}
-    .muted{color:var(--muted)}
-    .divider{height:1px;background:#e5e7eb;margin:24px 0}
-
-    .book-hero{display:grid;gap:22px;align-items:start}
-    @media(min-width:980px){ .book-hero{grid-template-columns: 280px 1fr} }
-    .book-cover{width:100%;height:auto;border-radius:12px;box-shadow:0 10px 28px rgba(0,0,0,.12)}
-    .book-head h2{margin:.1rem 0 .35rem;font-size:1.75rem}
-    .status-pill{display:inline-block;font-size:.75rem;border:1px solid #e5e7eb;border-radius:999px;padding:.22rem .6rem;margin-right:.4rem}
-    .cta-row{display:flex;gap:.6rem;flex-wrap:wrap;margin-top:.6rem}
-    .btn{display:inline-block;padding:.7rem 1.1rem;border-radius:.7rem;background:#111827;color:#fff;font-weight:700;text-decoration:none}
-    .btn:hover{filter:brightness(1.08)}
-    .btn.ghost{background:transparent;color:#111827;border:2px solid #111827}
-
-    .desc p{margin:.65rem 0;line-height:1.7}
-    .blurbs{display:grid;gap:16px;margin-top:18px}
-    @media(min-width:980px){ .blurbs{grid-template-columns: repeat(2,1fr)} }
-    .blurb{background:#fff;border:1px solid rgba(160,125,59,.25);border-radius:12px;padding:16px;box-shadow:0 6px 18px rgba(0,0,0,.06)}
-    .blurb blockquote{margin:0 0 .6rem;font-size:1.05rem;line-height:1.6}
-    .blurb small{color:var(--muted)}
-
-    .more-wrap{margin-top:28px}
-    .grid{display:grid;gap:16px}
-    @media(min-width:900px){ .grid.cols-3{grid-template-columns:repeat(3,1fr)} }
-    .card{background:#fff;border:1px solid rgba(160,125,59,.25);border-radius:12px;padding:16px;transition:.2s}
-    .card:hover{border-color:rgba(160,125,59,.5);box-shadow:0 10px 26px rgba(0,0,0,.08);transform:translateY(-2px)}
+    .book-hero {
+      display: grid;
+      gap: 2rem;
+    }
+    @media (min-width: 980px) {
+      .book-hero {
+        grid-template-columns: minmax(0, 320px) minmax(0, 1fr);
+      }
+    }
+    .status-pill {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.35rem;
+      padding: 0.3rem 0.85rem;
+      border-radius: 999px;
+      border: 1px solid rgba(98, 87, 165, 0.5);
+      background: rgba(98, 87, 165, 0.15);
+      color: rgba(233, 232, 245, 0.9);
+      font-size: 0.75rem;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+    }
+    .blurb {
+      border: 1px solid rgba(94, 108, 155, 0.55);
+      border-radius: var(--radius-md);
+      padding: 1.2rem;
+      background: rgba(18, 22, 44, 0.82);
+      box-shadow: var(--shadow-card);
+    }
+    .blurb blockquote {
+      margin: 0 0 0.6rem;
+      font-size: 1.05rem;
+      color: var(--ink);
+    }
   </style>
-
-  <!-- Load data BEFORE scripting -->
-  <script src="./js/data/data.js"></script>
+  <script defer src="./js/data/data.js"></script>
 </head>
-<body class="page">
+<body class="page page--books">
   <div class="shell">
-    <header class="site-header">
+    <header class="site-header" aria-label="Site">
       <a class="brand" href="./index.html">Michael C. Barros</a>
-      <nav class="nav" aria-label="Main">
-        <a href="./about.html">About</a>
-        <a href="./books.html" aria-current="page">Books</a>
-        <a id="nav-blog" href="https://mythonoesis.substack.com/" target="_blank" rel="noopener">Blog</a>
-        <a href="./projects.html">Projects</a>
-        <a id="nav-research" href="#" target="_blank" rel="noopener">Research</a>
-        <a href="./contact.html">Contact</a>
+      <nav class="nav" aria-label="Primary">
+        <a class="nav__link" href="./about.html">About</a>
+        <a class="nav__link" href="./books.html" aria-current="page">Books</a>
+        <a class="nav__link" id="nav-blog" href="https://mythonoesis.substack.com/" target="_blank" rel="noopener">Blog</a>
+        <a class="nav__link" href="./projects.html">Projects</a>
+        <a class="nav__link" id="nav-research" href="#" target="_blank" rel="noopener">Research</a>
+        <a class="nav__link" href="./contact.html">Contact</a>
       </nav>
     </header>
 
-    <section>
-      <h1 class="page-title">Books</h1>
-      <p class="muted">Published and forthcoming work on religion and popular culture.</p>
-    </section>
+    <main>
+      <section class="page-header">
+        <span class="eyebrow">Books</span>
+        <h1 class="page-title">Theology, myth, and the popular imagination</h1>
+        <p class="page-kicker">Published and forthcoming work exploring how sacred imagination moves through games, film, and speculative fiction.</p>
+      </section>
 
-    <div class="divider"></div>
-
-    <!-- Featured book -->
-    <section aria-labelledby="featured-heading">
-      <h2 id="featured-heading" style="margin:0 0 .6rem">Featured</h2>
-      <div class="book-hero" id="book-hero">
-        <img class="book-cover" src="./assets/images/books/placeholder.jpg" alt="Book cover" loading="lazy">
-        <div class="book-head">
-          <h2>Current Book</h2>
-          <p class="muted">Add book details in <code>js/data/data.js</code>.</p>
-          <div class="cta-row">
-            <a class="btn" href="#" id="buy-link" target="_blank" rel="noopener">Buy on Amazon</a>
-          </div>
+      <section aria-labelledby="featured-heading">
+        <div class="section-heading">
+          <h2 id="featured-heading">Featured</h2>
         </div>
-      </div>
+        <article class="section-card">
+          <div class="book-hero" id="book-hero">
+            <img class="book-cover" src="data:image/svg+xml;charset=UTF-8,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20viewBox%3D%270%200%20400%20600%27%3E%0A%20%20%3Crect%20width%3D%27400%27%20height%3D%27600%27%20fill%3D%27%2311152a%27/%3E%0A%20%20%3Crect%20x%3D%2740%27%20y%3D%2748%27%20width%3D%27320%27%20height%3D%27504%27%20rx%3D%2724%27%20fill%3D%27none%27%20stroke%3D%27%236257a5%27%20stroke-width%3D%272%27/%3E%0A%20%20%3Cpath%20d%3D%27M80%20160h240M80%20300h240M80%20440h240%27%20stroke%3D%27%233f4668%27%20stroke-width%3D%271%27/%3E%0A%20%20%3Ctext%20x%3D%2750%25%27%20y%3D%2752%25%27%20text-anchor%3D%27middle%27%20dominant-baseline%3D%27middle%27%20font-family%3D%27Playfair%20Display%2C%20serif%27%20font-size%3D%2748%27%20fill%3D%27%23d1b97a%27%20letter-spacing%3D%274%27%3EMyth%3C/text%3E%0A%3C/svg%3E" alt="Book cover" loading="lazy" />
+            <div class="book-copy">
+              <h3>Current Book</h3>
+              <p class="muted">Add book details in <code>js/data/data.js</code>.</p>
+              <div class="cta-row">
+                <a class="btn" href="#" id="buy-link" target="_blank" rel="noopener">Buy</a>
+              </div>
+            </div>
+          </div>
+          <div id="book-extras" class="detail-grid" style="margin-top: 2rem; display: none;">
+            <div class="book-copy" id="book-desc"></div>
+            <div class="detail-grid" id="book-blurbs"></div>
+          </div>
+        </article>
+      </section>
 
-      <!-- Description + blurbs -->
-      <div id="book-extras" class="more-wrap" style="display:none">
-        <div class="desc" id="book-desc"></div>
-        <div class="blurbs" id="book-blurbs"></div>
-      </div>
-    </section>
+      <section id="more-books" style="display: none; margin-top: 3rem;">
+        <div class="section-heading">
+          <h2>More titles</h2>
+        </div>
+        <div class="grid cols-3" id="books-grid"></div>
+      </section>
+    </main>
 
-    <!-- More books (hidden when there’s only one) -->
-    <section id="more-books" class="more-wrap" style="display:none">
-      <h2>More Books</h2>
-      <div class="grid cols-3" id="books-grid"></div>
-    </section>
-
-    <footer class="footer">© <span id="year"></span> Michael C. Barros</footer>
+    <footer>
+      <p class="footer-tagline">Myth · Media · Imagination</p>
+      © <span id="year"></span> Michael C. Barros
+    </footer>
   </div>
 
   <script>
-    // External links from data
-    (function(){
-      const LINKS = (window.SITE_DATA && window.SITE_DATA.links) || window.LINKS || {};
-      document.getElementById('nav-blog').href     = LINKS.blog || 'https://mythonoesis.substack.com/';
-      document.getElementById('nav-research').href = LINKS.research || 'https://www.researchgate.net/';
-      document.getElementById('year').textContent  = new Date().getFullYear();
-    })();
+    window.addEventListener('DOMContentLoaded', () => {
+      const year = document.getElementById('year');
+      if (year) year.textContent = new Date().getFullYear();
 
-    // Books rendering
-    (function(){
       const books = (window.SITE_DATA && window.SITE_DATA.books) || [];
       if (!books.length) return;
 
       const featured = books.find(b => b.featured) || books[0];
-
-      // Hero
       const hero = document.getElementById('book-hero');
-      const cover = featured.cover || featured.image || './assets/images/books/placeholder.jpg';
+      if (!hero) return;
+      const FALLBACK_COVER =
+        'data:image/svg+xml;charset=UTF-8,' +
+        encodeURIComponent(`
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 600">
+            <rect width="400" height="600" fill="#11152a" />
+            <rect x="40" y="48" width="320" height="504" rx="24" fill="none" stroke="#6257a5" stroke-width="2" />
+            <path d="M80 160h240M80 300h240M80 440h240" stroke="#3f4668" stroke-width="1" />
+            <text x="50%" y="52%" text-anchor="middle" dominant-baseline="middle" font-family="Playfair Display, serif" font-size="48" fill="#d1b97a" letter-spacing="4">Myth</text>
+          </svg>
+        `);
+      const cover = featured.cover || featured.image || FALLBACK_COVER;
       const status = featured.status ? `<span class="status-pill">${featured.status}</span>` : '';
       const buy = (featured.buy_links && featured.buy_links[0]) ? featured.buy_links[0] : null;
 
       hero.innerHTML = `
-        <img class="book-cover" src="${cover}" alt="${featured.title} cover" loading="lazy">
-        <div class="book-head">
+        <img class="book-cover" src="${cover}" alt="${featured.title} cover" loading="lazy" />
+        <div class="book-copy">
           <div>${status}</div>
-          <h2>${featured.title}</h2>
-          ${featured.summary ? `<p class="muted">${featured.summary}</p>` : ``}
+          <h3>${featured.title}</h3>
+          ${featured.summary ? `<p class="muted">${featured.summary}</p>` : ''}
           <div class="cta-row">
-            ${buy ? `<a class="btn" href="${buy.url}" target="_blank" rel="noopener">${buy.label || 'Buy'}</a>` : ``}
+            ${buy ? `<a class="btn" href="${buy.url}" target="_blank" rel="noopener">${buy.label || 'Buy'}</a>` : ''}
+            <a class="btn ghost" href="${featured.url || './books.html'}">Details</a>
           </div>
         </div>
       `;
 
-      // Description + blurbs
       const extras = document.getElementById('book-extras');
       const descEl = document.getElementById('book-desc');
       const blurbsEl = document.getElementById('book-blurbs');
 
       const paragraphs = (featured.description || '')
-        .split(/\n{2,}/).map(s=>s.trim()).filter(Boolean);
+        .split(/\n{2,}/)
+        .map(s => s.trim())
+        .filter(Boolean);
 
-      if (paragraphs.length) {
+      if (paragraphs.length && descEl) {
         descEl.innerHTML = paragraphs.map(p => `<p>${p}</p>`).join('');
       }
 
       const reviews = featured.reviews || [];
-      if (reviews.length) {
-        blurbsEl.innerHTML = reviews.slice(0,2).map(r => `
+      if (reviews.length && blurbsEl) {
+        blurbsEl.innerHTML = reviews.slice(0, 2).map(r => `
           <div class="blurb">
-            <blockquote>“${(r.quote || '').replace(/^"|”$/g,'')}”</blockquote>
-            <small>— ${r.source || 'Reviewer'}</small>
+            <blockquote>“${(r.quote || '').replace(/^"|”$/g, '')}”</blockquote>
+            <small class="muted">— ${r.source || 'Reviewer'}</small>
           </div>
         `).join('');
       }
 
-      if (paragraphs.length || reviews.length) {
-        extras.style.display = 'block';
+      if ((paragraphs.length || reviews.length) && extras) {
+        extras.style.display = 'grid';
       }
 
-      // More books (only if you add more later)
       const others = books.filter(b => b !== featured);
       if (others.length) {
         const wrap = document.getElementById('more-books');
         const grid = document.getElementById('books-grid');
-        grid.innerHTML = others.map(b => `
-          <article class="card">
-            <div style="display:flex; gap:12px">
-              ${b.cover ? `<img src="${b.cover}" alt="" style="width:80px;height:auto;border-radius:8px">` : ``}
-              <div>
-                <div class="status-pill">${b.status || 'Book'}</div>
-                <h3 style="margin:.35rem 0 .2rem">${b.title}</h3>
-                ${b.summary ? `<p class="muted">${b.summary}</p>` : ``}
-                ${(b.buy_links && b.buy_links[0]) ? `<p style="margin-top:.4rem"><a class="btn btn-sm" style="padding:.5rem .8rem" href="${b.buy_links[0].url}" target="_blank" rel="noopener">${b.buy_links[0].label || 'Buy'}</a></p>` : ``}
+        if (wrap && grid) {
+          grid.innerHTML = others.map(b => `
+            <article class="card">
+              <div class="feature-copy">
+                  ${b.cover ? `<img src="${b.cover}" alt="" style="width: 100%; max-width: 140px; border-radius: var(--radius-sm); box-shadow: 0 16px 32px rgba(5, 7, 18, 0.55);">` : ''}
+                <div>
+                  <div class="meta-row">
+                    <span class="status-pill">${b.status || 'Book'}</span>
+                  </div>
+                  <h3>${b.title}</h3>
+                  ${b.summary ? `<p>${b.summary}</p>` : ''}
+                  ${(b.buy_links && b.buy_links[0]) ? `<a class="btn ghost" style="margin-top: 0.6rem;" href="${b.buy_links[0].url}" target="_blank" rel="noopener">${b.buy_links[0].label || 'Buy'}</a>` : ''}
+                </div>
               </div>
-            </div>
-          </article>
-        `).join('');
-        wrap.style.display = 'block';
+            </article>
+          `).join('');
+          wrap.style.display = 'block';
+        }
       }
-    })();
+    });
   </script>
+  <script defer src="./js/nav.js"></script>
 </body>
 </html>

--- a/contact.html
+++ b/contact.html
@@ -1,86 +1,99 @@
 <!doctype html>
 <html lang="en">
 <head>
-  <meta charset="utf-8"/>
-  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Contact — Michael C. Barros</title>
-  <link rel="stylesheet" href="./style.css">
+  <meta name="description" content="Get in touch with Michael C. Barros for speaking, media, or collaboration." />
+  <link rel="stylesheet" href="./style.css" />
   <style>
-    :root{ --ink:#111827; --muted:#6b7280 }
-    .shell{max-width:720px;margin:0 auto;padding:24px 20px 48px}
-    .site-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:12px}
-    .brand{font-weight:700;text-decoration:none;color:var(--ink)}
-    .nav{display:flex;gap:18px;flex-wrap:wrap}
-    .nav a{color:var(--ink);text-decoration:none}
-    .nav a[aria-current="page"]{text-decoration:underline}
-    .muted{color:var(--muted)}
-    .card{background:#fff;border:1px solid #e5e7eb;border-radius:.85rem;padding:16px}
-    .btn{display:inline-block;padding:.6rem 1rem;border-radius:.6rem;background:#111827;color:#fff;text-decoration:none;font-weight:700}
-    .btn.ghost{background:transparent;color:#111827;border:2px solid #111827}
-    .row{display:flex;gap:.6rem;flex-wrap:wrap;align-items:center}
-    code.addr{padding:.25rem .4rem;background:#f8f8f8;border:1px solid #e5e7eb;border-radius:.4rem}
+    .contact-grid {
+      display: grid;
+      gap: 1.5rem;
+    }
+    .contact-actions {
+      display: flex;
+      gap: 0.75rem;
+      flex-wrap: wrap;
+      align-items: center;
+    }
   </style>
 </head>
-<body>
+<body class="page page--contact">
   <div class="shell">
-    <header class="site-header">
+    <header class="site-header" aria-label="Site">
       <a class="brand" href="./index.html">Michael C. Barros</a>
-      <nav class="nav" aria-label="Main">
-        <a href="./about.html">About</a>
-        <a href="./books.html">Books</a>
-        <a id="nav-blog" href="https://mythonoesis.substack.com/" target="_blank" rel="noopener">Blog</a>
-        <a href="./projects.html">Projects</a>
-        <a id="nav-research" href="#" target="_blank" rel="noopener">Research</a>
-        <a href="./contact.html" aria-current="page">Contact</a>
+      <nav class="nav" aria-label="Primary">
+        <a class="nav__link" href="./about.html">About</a>
+        <a class="nav__link" href="./books.html">Books</a>
+        <a class="nav__link" id="nav-blog" href="https://mythonoesis.substack.com/" target="_blank" rel="noopener">Blog</a>
+        <a class="nav__link" href="./projects.html">Projects</a>
+        <a class="nav__link" id="nav-research" href="#" target="_blank" rel="noopener">Research</a>
+        <a class="nav__link" href="./contact.html" aria-current="page">Contact</a>
       </nav>
     </header>
 
     <main>
-      <h1>Contact</h1>
-      <p class="muted">Speaking invitations, media requests, or collaboration.</p>
+      <section class="page-header">
+        <span class="eyebrow">Contact</span>
+        <h1 class="page-title">Contact &amp; Speaking</h1>
+        <p class="page-kicker">For speaking invitations, interviews, or collaborations, please include event details, proposed dates, and format. I respond to all messages as time permits.</p>
+      </section>
 
-      <div class="card">
-        <h2>Email</h2>
-        <p class="muted">I read all messages and reply as time permits.</p>
-        <div class="row">
-          <code id="addr" class="addr">michael<span aria-hidden="true">[at]</span>example<span aria-hidden="true">[dot]</span>com</code>
-          <button id="copy" class="btn">Copy</button>
-          <a id="mailto" class="btn ghost" href="#">Open mail app</a>
-        </div>
-      </div>
+      <section class="contact-grid">
+        <article class="section-card">
+          <h2>Email</h2>
+          <p>I read every message and respond as time permits.</p>
+          <div class="contact-actions">
+            <code id="addr">barrostheology@gmail.com</code>
+            <button id="copy" class="btn ghost" type="button">Copy</button>
+            <a id="mailto" class="btn" href="#">Open mail app</a>
+          </div>
+        </article>
 
-      <div class="divider"></div>
-
-      <div class="card">
-        <h2>Speaking</h2>
-        <p>Interested in a lecture or interview on religion & popular culture, games, or speculative fiction? Provide proposed date(s), audience, and format.</p>
-      </div>
+        <article class="section-card">
+          <h2>Speaking &amp; media</h2>
+          <p>For lectures, interviews, or workshops on religion and popular culture, please share institutional or publication context alongside logistics. Sessions are tailored for academic, community, and industry settings.</p>
+        </article>
+      </section>
     </main>
 
-    <footer class="footer" style="text-align:center;color:var(--muted);margin-top:32px;font-size:.95rem">
+    <footer>
+      <p class="footer-tagline">Myth · Media · Imagination</p>
       © <span id="year"></span> Michael C. Barros
     </footer>
   </div>
 
   <script defer src="./js/data/data.js"></script>
+  <script defer src="./js/nav.js"></script>
   <script>
-    // Pull configured links + email from data.js
-    const LINKS=(window.SITE_DATA&&SITE_DATA.links)||window.LINKS||{};
-    const EMAIL=(window.SITE_DATA&&SITE_DATA.contact&&SITE_DATA.contact.email)||"michael@example.com";
-    document.getElementById('nav-blog').href = LINKS.blog || 'https://mythonoesis.substack.com/';
-    document.getElementById('nav-research').href = LINKS.research || 'https://www.researchgate.net/';
-    document.getElementById('year').textContent = new Date().getFullYear();
+    window.addEventListener('DOMContentLoaded', () => {
+      const LINKS = (window.SITE_DATA && window.SITE_DATA.links) || window.LINKS || {};
+      const EMAIL = (window.SITE_DATA && window.SITE_DATA.contact && window.SITE_DATA.contact.email) || 'barrostheology@gmail.com';
 
-    // Simple obfuscation replacement + copy
-    const addrEl=document.getElementById('addr');
-    addrEl.textContent = EMAIL;
-    document.getElementById('mailto').href = `mailto:${EMAIL}`;
-    document.getElementById('copy').addEventListener('click', async ()=>{
-      try { await navigator.clipboard.writeText(EMAIL); }
-      catch {}
-      const b = document.getElementById('copy');
-      b.textContent = "Copied";
-      setTimeout(()=> b.textContent = "Copy", 1200);
+      const blog = document.getElementById('nav-blog');
+      if (blog) blog.href = LINKS.blog || 'https://mythonoesis.substack.com/';
+      const research = document.getElementById('nav-research');
+      if (research) research.href = LINKS.research || 'https://www.researchgate.net/';
+
+      const addrEl = document.getElementById('addr');
+      if (addrEl) addrEl.textContent = EMAIL;
+
+      const mailto = document.getElementById('mailto');
+      if (mailto) mailto.href = `mailto:${EMAIL}`;
+
+      const copy = document.getElementById('copy');
+      if (copy) {
+        copy.addEventListener('click', async () => {
+          try { await navigator.clipboard.writeText(EMAIL); }
+          catch {}
+          copy.textContent = 'Copied';
+          setTimeout(() => { copy.textContent = 'Copy'; }, 1200);
+        });
+      }
+
+      const year = document.getElementById('year');
+      if (year) year.textContent = new Date().getFullYear();
     });
   </script>
 </body>

--- a/index.html
+++ b/index.html
@@ -1,331 +1,323 @@
 <!doctype html>
 <html lang="en">
 <head>
-  <meta charset="utf-8"/>
-  <meta name="viewport" content="width=device-width, initial-scale=1"/>
-  <title>Michael C. Barros — Scholar of Religion & Popular Culture</title>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Michael C. Barros — Tracing the Sacred in Contemporary Media</title>
+  <meta name="description" content="Michael C. Barros studies how sacred imagination manifests across games, film, and speculative fiction through rigorous theological and cultural analysis." />
+  <meta name="theme-color" content="#050310" />
 
-  <meta name="description" content="Where myth and meaning surface in games, film, and fiction. Books, selected writing, media, and speaking.">
-  <meta name="theme-color" content="#1f2937">
-
-  <link rel="stylesheet" href="./style.css">
-
-  <style>
-    /* Light augmentation that cooperates with style.css */
-    :root{
-      --ink:#111827; --muted:#6b7280; --accent:#0f766e; --bg:#F7F4EE; --card:#fff; --ring:rgba(15,118,110,.25);
-    }
-    body{background:var(--bg);color:var(--ink)}
-    .shell{max-width:1060px;margin:0 auto;padding:20px 20px 48px}
-
-    /* Header / nav */
-    .site-header{display:flex;align-items:center;justify-content:space-between;padding:10px 0}
-    .brand{font-weight:700;text-decoration:none;color:var(--ink)}
-    .nav{display:flex;gap:18px;flex-wrap:wrap}
-    .nav a{color:var(--ink);text-decoration:none}
-    .nav a:hover{text-decoration:underline}
-
-    /* Hero */
-    .hero{padding:42px 0 20px;text-align:center}
-    .hero h1{margin:.25rem 0 .4rem;font-size:clamp(1.8rem,2.8vw,2.6rem)}
-    .tagline{color:var(--muted);min-height:1.6em;transition:opacity .35s}
-    .cta-row{display:flex;gap:.75rem;justify-content:center;flex-wrap:wrap;margin-top:14px}
-    .btn{display:inline-block;padding:.7rem 1.1rem;border-radius:.7rem;background:var(--ink);color:#fff;text-decoration:none;font-weight:700}
-    .btn:hover{filter:brightness(1.08)}
-    .btn.ghost{background:transparent;color:var(--ink);border:2px solid var(--ink)}
-    .divider{height:1px;background:#e5e7eb;margin:28px 0}
-
-    /* Cards */
-    .grid{display:grid;gap:16px}
-    @media(min-width:900px){.grid.cols-3{grid-template-columns:repeat(3,1fr)}.grid.cols-2{grid-template-columns:repeat(2,1fr)}}
-    .card{background:var(--card);border:1px solid rgba(160,125,59,.25);border-radius:12px;padding:16px;transition:.2s;color:inherit;text-decoration:none;display:block}
-    .card:hover{border-color:rgba(160,125,59,.5);box-shadow:0 10px 26px rgba(0,0,0,.08);transform:translateY(-2px)}
-    .badge{display:inline-block;border:1px solid rgba(160,125,59,.35);color:var(--accent);font-family:'IBM Plex Mono',monospace;font-size:.72rem;padding:.15rem .45rem;border-radius:.4rem;margin-bottom:.35rem}
-
-    /* Flip card (for projects / writing previews) */
-    .flip{perspective:1000px}
-    .flip-inner{position:relative;transform-style:preserve-3d;transition:transform .5s}
-    .flip:hover .flip-inner{transform:rotateY(180deg)}
-    .flip-face{backface-visibility:hidden}
-    .flip-back{position:absolute;inset:0;transform:rotateY(180deg)}
-    .flip-face,.flip-back{border-radius:12px;border:1px solid rgba(160,125,59,.25);padding:16px;background:#fff}
-
-    .section-head{display:flex;align-items:baseline;justify-content:space-between;margin:0 0 .6rem}
-    .section-head h2{margin:0;font-size:1.25rem}
-    .section-head a{color:var(--accent);text-decoration:none;font-weight:600}
-    .section-head a:hover{text-decoration:underline}
-
-    /* --- Featured Book container ("dynamic box") --- */
-    .section-card{
-      background:#fff;
-      border:1px solid rgba(160,125,59,.25);
-      border-radius:16px;
-      box-shadow:0 8px 26px rgba(0,0,0,.06);
-      padding:18px;
-    }
-    @media (min-width:900px){ .section-card{ padding:22px 22px; } }
-
-/* --- Featured Book layout --- */
-.section-card{
-  background:#fff;
-  border:1px solid rgba(160,125,59,.25);
-  border-radius:16px;
-  box-shadow:0 8px 26px rgba(0,0,0,.06);
-  padding:18px;
-}
-@media (min-width:900px){ .section-card{ padding:22px 22px; } }
-
-.book-hero{
-  display:grid;
-  gap:24px;                 /* a touch more breathing room */
-  align-items:start;        /* grid items start at the top */
-}
-@media (min-width:900px){
-  .book-hero{ grid-template-columns: 380px 1fr; }  /* was 360 */
-}
-@media (min-width:1280px){
-  .book-hero{ grid-template-columns: 420px 1fr; }  /* was 400 */
-}
-
-.book-cover{
-  display:block;            /* prevents inline-img baseline jiggle */
-  width:100%;
-  height:auto;
-  border-radius:12px;
-  box-shadow:0 12px 30px rgba(0,0,0,.12);
-  background:#fff;
-  object-fit:contain;
-  align-self:start;         /* top-align the image within the grid cell */
-  margin:0;                 /* guard against UA margins */
-}
-
-.book-copy{
-  align-self:start;         /* top-align the text column too */
-  display:flex;
-  flex-direction:column;
-  gap:.6rem;
-}
-
-.book-copy h3{ margin:.2rem 0 0; font-size:1.55rem; } /* no top bump */
-.book-copy .muted{ margin-bottom:.35rem; }
-.book-copy .book-desc{ margin-top:.4rem; max-width:72ch; }
-.book-desc p{ margin:.65rem 0; line-height:1.7; }
-
-
-    .footer{text-align:center;color:var(--muted);margin-top:32px;font-size:.95rem}
-  </style>
+  <link rel="stylesheet" href="./style.css" />
 </head>
 
-<body>
+<body class="home">
   <div class="shell">
-    <!-- HEADER -->
-    <header class="site-header">
+    <header class="site-header" aria-label="Site">
       <a class="brand" href="./index.html">Michael C. Barros</a>
-      <nav class="nav" aria-label="Main">
-        <a href="./about.html">About</a>
-        <a href="./books.html">Books</a>
-        <a id="nav-blog" href="#" target="_blank" rel="noopener">Blog</a>
-        <a href="./projects.html">Projects</a>
-        <a id="nav-research" href="#" target="_blank" rel="noopener">Research</a>
-        <a href="./contact.html">Contact</a>
+      <nav class="nav" aria-label="Primary">
+        <a class="nav__link" href="./about.html">About</a>
+        <a class="nav__link" href="./books.html">Books</a>
+        <a class="nav__link" id="nav-blog" href="#" target="_blank" rel="noopener">Blog</a>
+        <a class="nav__link" href="./projects.html">Projects</a>
+        <a class="nav__link" id="nav-research" href="#" target="_blank" rel="noopener">Research</a>
+        <a class="nav__link" href="./contact.html">Contact</a>
       </nav>
     </header>
 
-    <!-- HERO -->
-    <section class="hero" aria-labelledby="title">
-      <h1 id="title">Michael C. Barros</h1>
-      <p id="rotating" class="tagline">
-        Where myth and meaning surface in games, film, and fiction.
-      </p>
-      <div class="cta-row" role="group" aria-label="Primary actions">
-        <a class="btn" href="./books.html">Explore Books →</a>
-        <a class="btn ghost" id="cta-blog" href="#" target="_blank" rel="noopener">Visit Substack →</a>
-      </div>
-    </section>
-
-    <div class="divider" role="presentation"></div>
-
-<!-- FEATURED BOOK -->
-<section aria-labelledby="book-heading">
-  <div class="section-head">
-    <h2 id="book-heading">Featured Book</h2>
-    <a href="./books.html" style="color:var(--brand);text-decoration:none;font-weight:600">All books →</a>
-  </div>
-
-  <div class="feature-box">
-    <div class="feature-grid" id="book-hero">
-      <!-- JS will inject cover + copy + full description -->
-      <div class="feature-media"><img src="./assets/images/books/placeholder.jpg" alt="Book cover" loading="lazy"></div>
-      <div class="feature-body">
-        <h3>Your Current Book</h3>
-        <p class="muted">Add details in <code>js/data/data.js</code> to populate this section.</p>
-        <div class="cta-row">
-          <a class="btn" href="./books.html">Learn more</a>
-          <a class="btn ghost" href="./books.html">Buy</a>
-        </div>
-        <div class="desc"></div>
-      </div>
-    </div>
-  </div>
-</section>
-
-
-    <div class="divider" role="presentation"></div>
-
-    <!-- PROJECTS -->
-    <section aria-labelledby="projects-heading">
-      <div class="section-head">
-        <h2 id="projects-heading">Projects</h2>
-        <a href="./projects.html">More →</a>
-      </div>
-      <div class="grid cols-3" id="projects-grid">
-        <!-- Fallback static cards; JS will replace if projects exist -->
-        <div class="flip">
-          <div class="flip-inner">
-            <div class="flip-face">
-              <span class="badge">Waypoint</span>
-              <h3>Waypoint Institute</h3>
-              <p class="muted">Research and publishing initiative (coming soon).</p>
+    <main>
+      <section class="hero" aria-labelledby="home-title">
+        <div class="hero__content">
+          <h1 id="home-title">Tracing the Sacred in Contemporary Media</h1>
+          <p id="rotating" class="hero__tagline">
+            Scholarship at the intersection of religion, imagination, and popular culture.
+          </p>
+          <div class="hero__meta">
+            <div class="badge-row" aria-label="Areas of focus">
+              <span class="badge">Games</span>
+              <span class="badge">Film</span>
+              <span class="badge">Speculative Fiction</span>
             </div>
-            <div class="flip-back">
-              <h3>Waypoint Institute</h3>
-              <p class="muted">A space for myth, meaning, and media praxis. Learn more →</p>
+            <div class="cta-row" role="group" aria-label="Primary actions">
+              <a class="btn" href="./books.html">Explore Books →</a>
+              <a class="btn ghost" id="cta-blog" href="#" target="_blank" rel="noopener">Visit Substack →</a>
             </div>
           </div>
         </div>
-        <a class="card" href="./books.html">
-          <span class="badge">In Progress</span>
-          <h3>Zelda & Religion</h3>
-          <p class="muted">Time, sacrifice, and mythopoesis in The Legend of Zelda.</p>
-        </a>
-        <a class="card" href="./books.html">
-          <span class="badge">Forthcoming</span>
-          <h3>The Esoteric Theology of Philip K. Dick</h3>
-          <p class="muted">Metaphysics of time and the sacred in PKD.</p>
-        </a>
-      </div>
-    </section>
+        <div class="hero__media" aria-hidden="true">
+          <div class="hero__motif">
+            <svg viewBox="0 0 200 200" role="presentation" aria-hidden="true">
+              <circle cx="100" cy="100" r="74" stroke="rgba(193,201,222,0.5)" stroke-width="1" fill="none" />
+              <circle cx="100" cy="100" r="32" stroke="rgba(193,201,222,0.25)" stroke-width="1" fill="none" />
+              <path d="M26 100h148M100 26v148" stroke="rgba(209,199,158,0.4)" stroke-width="1" />
+              <path d="M56 56l88 88M56 144l88-88" stroke="rgba(193,201,222,0.3)" stroke-width="1" />
+              <circle cx="100" cy="100" r="4" fill="rgba(209,199,158,0.8)" />
+            </svg>
+          </div>
+        </div>
+      </section>
 
-    <div class="divider" role="presentation"></div>
+      <div class="divider" role="presentation"></div>
 
-    <!-- MEDIA / LATEST FROM SUBSTACK -->
-    <section aria-labelledby="media-heading">
-      <div class="section-head">
-        <h2 id="media-heading">Latest from Substack</h2>
-        <a id="open-substack" href="#" target="_blank" rel="noopener">Open Substack →</a>
-      </div>
-      <div class="grid cols-3" id="substack-cards"></div>
-    </section>
+      <section aria-labelledby="book-heading">
+        <div class="section-heading">
+          <h2 id="book-heading">Featured Book</h2>
+          <a class="link" href="./books.html">All books →</a>
+        </div>
+        <article class="section-card">
+          <div class="feature-grid two-col" id="book-hero">
+            <div class="feature-media">
+              <img src="data:image/svg+xml;charset=UTF-8,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20viewBox%3D%270%200%20400%20600%27%3E%0A%20%20%3Crect%20width%3D%27400%27%20height%3D%27600%27%20fill%3D%27%2311152a%27/%3E%0A%20%20%3Crect%20x%3D%2740%27%20y%3D%2748%27%20width%3D%27320%27%20height%3D%27504%27%20rx%3D%2724%27%20fill%3D%27none%27%20stroke%3D%27%236257a5%27%20stroke-width%3D%272%27/%3E%0A%20%20%3Cpath%20d%3D%27M80%20160h240M80%20300h240M80%20440h240%27%20stroke%3D%27%233f4668%27%20stroke-width%3D%271%27/%3E%0A%20%20%3Ctext%20x%3D%2750%25%27%20y%3D%2752%25%27%20text-anchor%3D%27middle%27%20dominant-baseline%3D%27middle%27%20font-family%3D%27Playfair%20Display%2C%20serif%27%20font-size%3D%2748%27%20fill%3D%27%23d1b97a%27%20letter-spacing%3D%274%27%3EMyth%3C/text%3E%0A%3C/svg%3E" alt="Book cover" loading="lazy" />
+            </div>
+            <div class="book-copy">
+              <h3>Your Current Book</h3>
+              <p class="muted">Add details in <code>js/data/data.js</code> to populate this section.</p>
+              <div class="cta-row">
+                <a class="btn" href="./books.html">Learn more</a>
+                <a class="btn ghost" href="./books.html">Buy</a>
+              </div>
+              <div class="book-desc"></div>
+            </div>
+          </div>
+        </article>
+      </section>
 
-    <footer class="footer">© <span id="year"></span> Michael C. Barros</footer>
+      <div class="divider" role="presentation"></div>
+
+      <section aria-labelledby="projects-heading">
+        <div class="section-heading">
+          <h2 id="projects-heading">Projects</h2>
+          <a class="link" href="./projects.html">Browse all →</a>
+        </div>
+        <div class="grid cols-3" id="projects-grid">
+          <a class="card" href="./projects.html">
+            <span class="card__motif" aria-hidden="true">
+              <svg viewBox="0 0 120 120">
+                <circle cx="60" cy="60" r="36" />
+                <path d="M60 18v84M18 60h84" />
+              </svg>
+            </span>
+            <span class="badge">Waypoint</span>
+            <h3>Waypoint Institute</h3>
+            <p>Research and publishing initiative (coming soon).</p>
+          </a>
+          <a class="card" href="./books.html">
+            <span class="card__motif" aria-hidden="true">
+              <svg viewBox="0 0 120 120">
+                <path d="M60 24l30 52H30z" />
+                <path d="M60 24v52" />
+              </svg>
+            </span>
+            <span class="badge">In Progress</span>
+            <h3>Zelda &amp; Religion</h3>
+            <p>Time, sacrifice, and mythopoesis in The Legend of Zelda.</p>
+          </a>
+          <a class="card" href="./books.html">
+            <span class="card__motif" aria-hidden="true">
+              <svg viewBox="0 0 120 120">
+                <rect x="28" y="28" width="64" height="64" rx="4" />
+                <path d="M28 60h64M60 28v64" />
+              </svg>
+            </span>
+            <span class="badge">Forthcoming</span>
+            <h3>The Esoteric Theology of Philip K. Dick</h3>
+            <p>Metaphysics of time and the sacred in PKD.</p>
+          </a>
+        </div>
+      </section>
+
+      <div class="divider" role="presentation"></div>
+
+      <section aria-labelledby="media-heading">
+        <div class="section-heading">
+          <h2 id="media-heading">Latest from Substack</h2>
+          <a class="link" id="open-substack" href="#" target="_blank" rel="noopener">Open Substack →</a>
+        </div>
+        <div class="grid cols-3" id="substack-cards">
+          <div class="empty" style="grid-column: 1/-1;">
+            Add posts in <code>js/data/data.js</code> to surface Substack updates.
+          </div>
+        </div>
+      </section>
+
+      <div class="divider" role="presentation"></div>
+
+      <section aria-labelledby="bio-heading">
+        <article class="section-card">
+          <div class="feature-grid two-col">
+            <div class="feature-media feature-media--avatar" role="img" aria-label="Abstract portrait of Michael C. Barros"></div>
+            <div class="feature-body">
+              <span class="eyebrow">About Michael</span>
+              <h3 id="bio-heading">Scholar of religion &amp; popular culture</h3>
+              <p>Exploring how sacred imagination moves through games, film, and speculative fiction with theological and cultural frameworks for contemporary storytelling.</p>
+              <div class="cta-row">
+                <a class="btn ghost" href="./about.html">Read full bio</a>
+                <a class="btn" href="./contact.html">Connect</a>
+              </div>
+            </div>
+          </div>
+        </article>
+      </section>
+    </main>
+
+    <footer>
+      <p class="footer-tagline">Myth · Media · Imagination</p>
+      © <span id="year"></span> Michael C. Barros
+    </footer>
   </div>
 
-  <!-- Data + shared nav config -->
   <script defer src="./js/data/data.js"></script>
   <script defer src="./js/nav.js"></script>
-
   <script>
     window.addEventListener('DOMContentLoaded', () => {
-      // --- rotating tagline ---
+      // rotating tagline
       (function(){
         const el = document.getElementById('rotating');
         const lines = (window.SITE_DATA && window.SITE_DATA.taglines) || [
-          "Where myth and meaning surface in games, film, and fiction.",
-          "Exploring how culture becomes a site of religious experience.",
-          "Religion, imagination, and popular culture."
+          'Where myth and meaning surface in games, film, and fiction.',
+          'Interpreting popular media as sites of religious experience.',
+          'Religion, imagination, and contemporary culture.'
         ];
+        if (!el) return;
         let i = 0;
-        setInterval(()=>{ i=(i+1)%lines.length; el.style.opacity=0; setTimeout(()=>{ el.textContent = lines[i]; el.style.opacity=1; },180);}, 4200);
+        const reduceMotion = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+        if (lines.length < 2 || reduceMotion) {
+          el.textContent = lines[0];
+          return;
+        }
+        el.textContent = lines[0];
+        setInterval(() => {
+          i = (i + 1) % lines.length;
+          el.style.opacity = 0;
+          setTimeout(() => {
+            el.textContent = lines[i];
+            el.style.opacity = 1;
+          }, 180);
+        }, 4200);
       })();
 
-      // --- footer year ---
-      document.getElementById('year').textContent = new Date().getFullYear();
+      // footer year
+      const year = document.getElementById('year');
+      if (year) year.textContent = new Date().getFullYear();
 
-      // --- featured book (bigger cover + full description; NO reviews on home) ---
+      // featured book
       (function(){
+        const FALLBACK_COVER =
+          'data:image/svg+xml;charset=UTF-8,' +
+          encodeURIComponent(`
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 600">
+              <rect width="400" height="600" fill="#11152a" />
+              <rect x="40" y="48" width="320" height="504" rx="24" fill="none" stroke="#6257a5" stroke-width="2" />
+              <path d="M80 160h240M80 300h240M80 440h240" stroke="#3f4668" stroke-width="1" />
+              <text x="50%" y="52%" text-anchor="middle" dominant-baseline="middle" font-family="Playfair Display, serif" font-size="48" fill="#d1b97a" letter-spacing="4">Myth</text>
+            </svg>
+          `);
+
         const books = (window.SITE_DATA && window.SITE_DATA.books) || window.BOOKS || [];
         if (!books.length) return;
-        const featured = books.find(b=>b.featured) || books[0];
+        const featured = books.find(b => b.featured) || books[0];
         const hero = document.getElementById('book-hero');
+        if (!hero) return;
 
-        const cover = featured.cover || featured.image || './assets/images/books/placeholder.jpg';
-        const url   = featured.url || './books.html';
-        const buy   = (featured.buy_links && featured.buy_links[0]) ? featured.buy_links[0] : null;
-        const desc  = featured.description || featured.summary || "";
+        const cover = featured.cover || featured.image || FALLBACK_COVER;
+        const url = featured.url || './books.html';
+        const buy = (featured.buy_links && featured.buy_links[0]) ? featured.buy_links[0] : null;
+        const desc = featured.description || featured.summary || '';
 
         hero.innerHTML = `
-          <img class="book-cover" src="${cover}" alt="${featured.title} cover" loading="lazy">
+          <div class="feature-media">
+            <img class="book-cover" src="${cover}" alt="${featured.title} cover" loading="lazy" />
+          </div>
           <div class="book-copy">
             <h3>${featured.title}</h3>
             ${featured.summary ? `<p class="muted">${featured.summary}</p>` : ``}
-            <div class="cta-row" style="justify-content:flex-start">
+            <div class="cta-row">
               <a class="btn" href="${url}">Learn more</a>
               ${buy ? `<a class="btn ghost" href="${buy.url}" target="_blank" rel="noopener">${buy.label || 'Buy'}</a>` : ``}
             </div>
             <div class="book-desc">
-              ${desc.split(/\n{2,}/).map(p=>`<p>${p.trim()}</p>`).join("")}
+              ${desc.split(/\n{2,}/).map(p => `<p>${p.trim()}</p>`).join('')}
             </div>
           </div>
         `;
       })();
 
-      // --- projects (flip cards) ---
+      // projects
       (function(){
         const projects = (window.SITE_DATA && window.SITE_DATA.projects) || window.PROJECTS || [];
-        if (!projects.length) return; // keep the static 3
+        if (!projects.length) return;
         const grid = document.getElementById('projects-grid');
+        if (!grid) return;
+        const motif = (id) => {
+          switch (id) {
+            case 'waypoint':
+              return '<span class="card__motif" aria-hidden="true"><svg viewBox="0 0 120 120"><circle cx="60" cy="60" r="40" /><path d="M60 22v76M22 60h76" /></svg></span>';
+            case 'zelda-religion':
+              return '<span class="card__motif" aria-hidden="true"><svg viewBox="0 0 120 120"><path d="M60 24l32 56H28z" /><path d="M60 24v56" /></svg></span>';
+            case 'pkd-theology-proj':
+            case 'pkd-theology':
+              return '<span class="card__motif" aria-hidden="true"><svg viewBox="0 0 120 120"><rect x="28" y="28" width="64" height="64" rx="6" /><path d="M28 60h64M60 28v64" /></svg></span>';
+            default:
+              return '<span class="card__motif" aria-hidden="true"><svg viewBox="0 0 120 120"><circle cx="60" cy="60" r="48" /><path d="M28 60h64M60 28v64" /></svg></span>';
+          }
+        };
         grid.innerHTML = '';
-        projects.slice(0,6).forEach(p=>{
+        projects.slice(0, 6).forEach(p => {
           if (p.description) {
-            const c = document.createElement('div');
-            c.className = 'flip';
-            c.innerHTML = `
-              <a class="flip-inner" href="${p.url || '#'}" ${p.external ? 'target="_blank" rel="noopener"':''}>
-                <div class="flip-face">
+            const card = document.createElement('div');
+            card.className = 'flip';
+            card.innerHTML = `
+              <div class="flip-inner">
+                <a class="flip-face" href="${p.url || '#'}" ${p.external ? 'target="_blank" rel="noopener"' : ''}>
                   <span class="badge">${p.status || p.type || 'Project'}</span>
                   <h3>${p.title}</h3>
-                  <p class="muted">${p.short || p.summary || ''}</p>
-                </div>
-                <div class="flip-back">
+                  <p>${p.short || p.summary || ''}</p>
+                </a>
+                <a class="flip-back" href="${p.url || '#'}" ${p.external ? 'target="_blank" rel="noopener"' : ''}>
                   <h3>${p.title}</h3>
-                  ${p.description ? `<p class="muted">${p.description}</p>` : ``}
-                </div>
-              </a>`;
-            grid.appendChild(c);
+                  ${p.description ? `<p>${p.description}</p>` : ''}
+                </a>
+              </div>
+            `;
+            grid.appendChild(card);
           } else {
-            const a = document.createElement('a');
-            a.className = 'card';
-            a.href = p.url || '#';
-            if (p.external) { a.target = "_blank"; a.rel = "noopener"; }
-            a.innerHTML = `<span class="badge">${p.status || p.type || 'Project'}</span><h3>${p.title}</h3><p class="muted">${p.short || p.summary || ''}</p>`;
-            grid.appendChild(a);
+            const link = document.createElement('a');
+            link.className = 'card';
+            link.href = p.url || '#';
+            if (p.external) { link.target = '_blank'; link.rel = 'noopener'; }
+            link.innerHTML = `
+              ${motif(p.id || p.title)}
+              <span class="badge">${p.status || p.type || 'Project'}</span>
+              <h3>${p.title}</h3>
+              <p>${p.short || p.summary || ''}</p>
+            `;
+            grid.appendChild(link);
           }
         });
       })();
 
-      // --- Substack (latest 3) ---
+      // substack
       (function(){
         const feed = document.getElementById('substack-cards');
         const posts = (window.SITE_DATA?.substack?.posts || window.SUBSTACK_POSTS || [])
           .slice()
-          .sort((a,b)=> new Date(b.date)-new Date(a.date))
-          .slice(0,3);
+          .sort((a, b) => new Date(b.date) - new Date(a.date))
+          .slice(0, 3);
         const blogUrl = (window.SITE_DATA?.links?.blog) || (window.LINKS?.blog) || 'https://mythonoesis.substack.com/';
-        document.getElementById('open-substack').href = blogUrl;
-
+        const open = document.getElementById('open-substack');
+        if (open) open.href = blogUrl;
         if (!feed) return;
-        if (!posts.length){
-          feed.innerHTML = `<div class="card muted" style="grid-column:1/-1">Add posts in <code>js/data/data.js</code> (SUBSTACK_POSTS).</div>`;
-          return;
-        }
-        posts.forEach(p=>{
+        if (!posts.length) return;
+        feed.innerHTML = '';
+        posts.forEach(post => {
           const a = document.createElement('a');
           a.className = 'card';
-          a.href = p.url; a.target = "_blank"; a.rel = "noopener";
+          a.href = post.url;
+          a.target = '_blank';
+          a.rel = 'noopener';
           a.innerHTML = `
-            <span class="badge">Substack</span>
-            <h3>${p.title}</h3>
-            <p class="muted">${p.summary || ''}</p>
+            <span class="badge">Post</span>
+            <h3>${post.title}</h3>
+            ${post.summary ? `<p>${post.summary}</p>` : ''}
           `;
           feed.appendChild(a);
         });
@@ -334,20 +326,3 @@
   </script>
 </body>
 </html>
-<section aria-labelledby="bio-heading" style="margin-top:22px">
-  <div class="feature-box">
-    <div class="feature-grid" style="grid-template-columns:minmax(120px,160px) 1fr">
-      <div class="feature-media">
-        <img src="./assets/images/headshot.jpg" alt="Michael C. Barros" loading="lazy">
-      </div>
-      <div class="feature-body">
-        <h3 id="bio-heading" style="margin-top:.1rem">About Michael</h3>
-        <p class="muted">Scholar of religion & popular culture, exploring how myth and meaning surface in games, film, and fiction.</p>
-        <div class="cta-row">
-          <a class="btn ghost" href="./about.html">Read full bio</a>
-          <a class="btn" href="./contact.html">Contact</a>
-        </div>
-      </div>
-    </div>
-  </div>
-</section>

--- a/js/data/data.js
+++ b/js/data/data.js
@@ -15,8 +15,8 @@
   // ---------- Taglines (homepage rotator) ----------
   const TAGLINES = [
     "Where myth and meaning surface in games, film, and fiction.",
-    "Exploring how culture becomes a site of religious experience.",
-    "Religion, imagination, and popular culture."
+    "Interpreting popular media as sites of religious experience.",
+    "Religion, imagination, and contemporary culture."
   ];
 
   // ---------- Books ----------

--- a/js/nav.js
+++ b/js/nav.js
@@ -1,38 +1,43 @@
-<!-- js/nav.js -->
-<script>
 (function () {
-  // Grab links from SITE_DATA (falls back to safe defaults)
   const LINKS = (window.SITE_DATA && window.SITE_DATA.links) || window.LINKS || {};
+  const blog = LINKS.blog || 'https://mythonoesis.substack.com/';
+  const research = LINKS.research || 'https://www.researchgate.net/';
 
-  function setHref(id, href) {
-    var el = document.getElementById(id);
+  [
+    { selector: '#nav-blog', href: blog },
+    { selector: '#cta-blog', href: blog },
+    { selector: '#open-substack', href: blog },
+    { selector: '#about-blog', href: blog }
+  ].forEach(({ selector, href }) => {
+    const el = document.querySelector(selector);
     if (el && href) el.setAttribute('href', href);
-  }
+  });
 
-  // Wire every place we might use these links
-  const blog   = LINKS.blog     || 'https://mythonoesis.substack.com/';
-  const rg     = LINKS.research || 'https://www.researchgate.net/';
+  [
+    { selector: '#nav-research', href: research },
+    { selector: '#about-research', href: research }
+  ].forEach(({ selector, href }) => {
+    const el = document.querySelector(selector);
+    if (el && href) el.setAttribute('href', href);
+  });
 
-  setHref('nav-blog', blog);
-  setHref('cta-blog', blog);
-  setHref('open-substack', blog);
-  setHref('nav-research', rg);
-
-  // Optional: mark active page in nav by pathname
   try {
     const path = (location.pathname || '').split('/').pop() || 'index.html';
     const map = {
-      'index.html': null,
+      'index.html': './index.html',
       'books.html': './books.html',
       'projects.html': './projects.html',
       'about.html': './about.html',
       'contact.html': './contact.html'
     };
-    const activeHref = map[path];
-    if (activeHref) {
-      const active = document.querySelector(`.nav a[href="${activeHref}"]`);
-      if (active) active.setAttribute('aria-current','page');
+    const target = map[path];
+    if (target) {
+      const link = document.querySelector(`.nav__link[href="${target}"]`);
+      if (link && !link.hasAttribute('aria-current')) {
+        link.setAttribute('aria-current', 'page');
+      }
     }
-  } catch {}
+  } catch (err) {
+    // no-op if location parsing fails
+  }
 })();
-</script>

--- a/js/projects.js
+++ b/js/projects.js
@@ -1,149 +1,179 @@
 // js/projects.js
 (function () {
-  "use strict";
+  'use strict';
 
-  // ----- Links from data.js for nav -----
-  const LINKS =
-    (window.SITE_DATA && window.SITE_DATA.links) ||
-    window.LINKS || {
-      blog: "https://mythonoesis.substack.com/",
-      research: "https://www.researchgate.net/",
-    };
-
-  const blogA = document.getElementById("nav-blog");
-  const resA = document.getElementById("nav-research");
-  if (blogA) blogA.href = LINKS.blog;
-  if (resA) resA.href = LINKS.research;
-
-  const year = document.getElementById("year");
+  const year = document.getElementById('year');
   if (year) year.textContent = new Date().getFullYear();
 
-  // ----- Utilities -----
-  const $ = (s) => document.querySelector(s);
-  const $$ = (s) => Array.from(document.querySelectorAll(s));
-  const slugify = (s) =>
-    (s || "")
-      .toLowerCase()
-      .trim()
-      .replace(/[^a-z0-9\s-]/g, "")
-      .replace(/\s+/g, "-")
-      .replace(/-+/g, "-");
-  const fmt = (iso) => {
-    try {
-      return new Date(iso).toISOString().slice(0, 10);
-    } catch {
-      return "";
-    }
-  };
+  const projects = getProjects();
+  buildFilters(projects);
 
-  // ----- Data normalization -----
+  const state = { k: 'All', q: '' };
+  renderGrid(projects, state);
+
+  const filters = document.getElementById('filters');
+  if (filters) {
+    filters.addEventListener('click', (event) => {
+      const btn = event.target.closest('button[data-k]');
+      if (!btn) return;
+      filters.querySelectorAll('button').forEach((b) => b.classList.remove('active'));
+      btn.classList.add('active');
+      state.k = btn.dataset.k || 'All';
+      renderGrid(projects, state);
+    });
+  }
+
+  const search = document.getElementById('search');
+  if (search) {
+    search.addEventListener('input', (event) => {
+      state.q = event.target.value || '';
+      renderGrid(projects, state);
+    });
+  }
+
   function getProjects() {
     const D = window.SITE_DATA || {};
-    let list = Array.isArray(D.projects) ? D.projects.slice() : window.PROJECTS || [];
+    const list = Array.isArray(D.projects) ? D.projects.slice() : window.PROJECTS || [];
     return list.map((p) => ({
-      id: p.id || slugify(p.title || ""),
-      title: p.title || "Untitled project",
-      status: p.status || p.type || "Project", // badge
-      type: p.type || "",
+      id: slugify(p.id || p.title || ''),
+      title: p.title || 'Untitled project',
+      status: p.status || p.type || 'Project',
+      type: p.type || '',
       tags: Array.isArray(p.tags)
         ? p.tags
         : p.tags
         ? String(p.tags)
-            .split(",")
+            .split(',')
             .map((t) => t.trim())
         : [],
-      date: p.date || p.started || "",
-      short: p.short || p.summary || "",
-      description: p.description || "",
+      date: p.date || p.started || '',
+      short: p.short || p.summary || '',
+      description: p.description || '',
       url: p.url || null,
+      cover: p.cover || p.image || null,
       external: !!p.external,
     }));
   }
 
-  // ----- Filters + Search -----
   function buildFilters(items) {
-    const filters = $("#filters");
-    if (!filters) return;
-    const kinds = new Set(["All"]);
+    const node = document.getElementById('filters');
+    if (!node) return;
+    const kinds = new Set(['All']);
     items.forEach((p) => {
       if (p.status) kinds.add(p.status);
       if (p.type) kinds.add(p.type);
     });
-    filters.innerHTML = "";
-    [...kinds].forEach((k, i) => {
-      const b = document.createElement("button");
-      b.type = "button";
-      b.className = "filter-btn" + (i === 0 ? " active" : "");
-      b.dataset.k = k;
-      b.textContent = k;
-      filters.appendChild(b);
+    node.innerHTML = '';
+    Array.from(kinds).forEach((kind, idx) => {
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'filter-btn' + (idx === 0 ? ' active' : '');
+      button.dataset.k = kind;
+      button.textContent = kind;
+      node.appendChild(button);
     });
   }
 
-  function renderGrid(items, { k = "All", q = "" } = {}) {
-    const grid = $("#projects-grid");
-    const empty = $("#empty");
+  function renderGrid(items, { k = 'All', q = '' } = {}) {
+    const grid = document.getElementById('projects-grid');
+    const empty = document.getElementById('empty');
     if (!grid) return;
 
     const ql = q.trim().toLowerCase();
     const filtered = items.filter((p) => {
-      const inKind = k === "All" || p.status === k || p.type === k;
-      const inSearch =
-        !ql ||
-        [p.title, p.short, p.description, p.tags.join(" ")]
-          .join(" ")
-          .toLowerCase()
-          .includes(ql);
+      const inKind = k === 'All' || p.status === k || p.type === k;
+      const haystack = [p.title, p.short, p.description, p.tags.join(' ')].join(' ').toLowerCase();
+      const inSearch = !ql || haystack.includes(ql);
       return inKind && inSearch;
     });
 
     if (!filtered.length) {
-      grid.innerHTML = "";
-      if (empty) empty.style.display = "block";
+      grid.innerHTML = '';
+      if (empty) empty.style.display = 'block';
       return;
-    } else if (empty) empty.style.display = "none";
+    }
 
-    grid.innerHTML = "";
+    if (empty) empty.style.display = 'none';
+    grid.innerHTML = '';
+
     filtered.forEach((p) => {
-     // Use flip card only when we have a cover image for a true "front"
-const hasCover = !!p.cover; // string URL expected
-if (hasCover) {
-  const c = document.createElement("div");
-  c.className = "flip";
-  c.innerHTML = `
-    <div class="flip-inner">
-      <a class="flip-face" href="${p.url || '#'}" ${p.external ? 'target="_blank" rel="noopener"':''}>
-        <img src="${p.cover}" alt="" style="width:100%;height:140px;object-fit:cover;border-radius:10px;margin-bottom:.6rem">
-        <span class="badge">${p.status}</span>
-        <h3>${p.title}</h3>
-        <div class="meta-row">
-          ${p.date ? `<time datetime="${p.date}">${fmt(p.date)}</time>` : ""}
-          ${p.tags.length ? `· ${p.tags.join(", ")}` : ""}
-        </div>
-        <p class="muted">${p.short}</p>
-      </a>
-      <a class="flip-back" href="${p.url || '#'}" ${p.external ? 'target="_blank" rel="noopener"':''}>
-        <h3>${p.title}</h3>
-        <p class="muted">${p.description || p.short || ""}</p>
-        ${p.url ? `<div style="margin-top:.5rem"><span class="badge">${p.external?'External':'More'}</span></div>` : ""}
-      </a>
-    </div>
-  `;
-  grid.appendChild(c);
-} else {
-  // standard card (no flip)
-  const a = document.createElement("a");
-  a.className = "card";
-  a.href = p.url || "#";
-  if (p.external){ a.target = "_blank"; a.rel = "noopener"; }
-  a.innerHTML = `
-    <span class="badge">${p.status}</span>
-    <h3>${p.title}</h3>
-    <div class="meta-row">
-      ${p.date ? `<time datetime="${p.date}">${fmt(p.date)}</time>` : ""}
-      ${p.tags.length ? `· ${p.tags.join(", ")}` : ""}
-    </div>
-    <p class="muted">${p.short}</p>
-  `;
-  grid.appendChild(a);
-}
+      if (p.cover) {
+        const wrapper = document.createElement('div');
+        wrapper.className = 'flip';
+        wrapper.innerHTML = `
+          <div class="flip-inner">
+            <a class="flip-face" href="${p.url || '#'}" ${p.external ? 'target="_blank" rel="noopener"' : ''}>
+              <img src="${p.cover}" alt="" style="width:100%;height:140px;object-fit:cover;border-radius:12px;margin-bottom:.6rem" />
+              <span class="badge">${p.status}</span>
+              <h3>${p.title}</h3>
+              <div class="meta-row">
+                ${p.date ? `<time datetime="${p.date}">${formatDate(p.date)}</time>` : ''}
+                ${p.tags.length ? `· ${p.tags.join(', ')}` : ''}
+              </div>
+              <p class="muted">${p.short}</p>
+            </a>
+            <a class="flip-back" href="${p.url || '#'}" ${p.external ? 'target="_blank" rel="noopener"' : ''}>
+              <h3>${p.title}</h3>
+              ${p.description ? `<p class="muted">${p.description}</p>` : ''}
+              ${p.url ? `<div style="margin-top:.65rem"><span class="badge">${p.external ? 'External' : 'Details'}</span></div>` : ''}
+            </a>
+          </div>
+        `;
+        grid.appendChild(wrapper);
+      } else {
+        const card = document.createElement('a');
+        card.className = 'card';
+        card.href = p.url || '#';
+        if (p.external) {
+          card.target = '_blank';
+          card.rel = 'noopener';
+        }
+        card.innerHTML = `
+          ${motifMarkup(p.id)}
+          <span class="badge">${p.status}</span>
+          <h3>${p.title}</h3>
+          <div class="meta-row">
+            ${p.date ? `<time datetime="${p.date}">${formatDate(p.date)}</time>` : ''}
+            ${p.tags.length ? `· ${p.tags.join(', ')}` : ''}
+          </div>
+          ${p.short ? `<p class="muted">${p.short}</p>` : ''}
+        `;
+        grid.appendChild(card);
+      }
+    });
+  }
+
+  function motifMarkup(id) {
+    const svg = (function () {
+      switch (id) {
+        case 'waypoint':
+          return '<svg viewBox="0 0 120 120"><circle cx="60" cy="60" r="40" /><path d="M60 22v76M22 60h76" /></svg>';
+        case 'zelda-religion':
+          return '<svg viewBox="0 0 120 120"><path d="M60 24l32 56H28z" /><path d="M60 24v56" /></svg>';
+        case 'pkd-theology-proj':
+        case 'pkd-theology':
+          return '<svg viewBox="0 0 120 120"><rect x="28" y="28" width="64" height="64" rx="6" /><path d="M28 60h64M60 28v64" /></svg>';
+        default:
+          return '<svg viewBox="0 0 120 120"><circle cx="60" cy="60" r="48" /><path d="M28 60h64M60 28v64" /></svg>';
+      }
+    })();
+    return `<span class="card__motif" aria-hidden="true">${svg}</span>`;
+  }
+
+  function slugify(value) {
+    return String(value || '')
+      .toLowerCase()
+      .trim()
+      .replace(/[^a-z0-9\s-]/g, '')
+      .replace(/\s+/g, '-')
+      .replace(/-+/g, '-');
+  }
+
+  function formatDate(value) {
+    try {
+      return new Date(value).toISOString().slice(0, 10);
+    } catch (err) {
+      return value;
+    }
+  }
+})();

--- a/projects.html
+++ b/projects.html
@@ -4,105 +4,64 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Projects — Michael C. Barros</title>
-  <meta name="description" content="Current work, collaborations, and research initiatives.">
+  <meta name="description" content="Current research, collaborations, and media experiments exploring myth and the sacred." />
   <link rel="stylesheet" href="./style.css" />
-
   <style>
-    /* Scoped, cooperative with style.css */
-    :root{ --ink:#111827; --muted:#6b7280; --ring:rgba(15,118,110,.25); }
-    .shell{max-width:1100px;margin:0 auto;padding:20px 20px 48px}
-    .site-header{display:flex;align-items:center;justify-content:space-between;padding:10px 0}
-    .brand{font-weight:700;text-decoration:none;color:var(--ink)}
-    .nav{display:flex;gap:18px;flex-wrap:wrap}
-    .nav a{color:var(--ink);text-decoration:none}
-    .nav a[aria-current="page"]{text-decoration:underline}
-    .nav a:hover{text-decoration:underline}
-
-    .hero--compact{padding:18px 0 6px}
-    .muted{color:var(--muted)}
-    .section-head{display:flex;align-items:baseline;justify-content:space-between;margin:0 0 .6rem}
-    .section-head h2{margin:0;font-size:1.25rem}
-
-    .toolbar{display:flex;gap:.6rem;flex-wrap:wrap;align-items:center;margin:.5rem 0 1rem}
-    .filters{display:flex;gap:.4rem;flex-wrap:wrap}
-    .filter-btn{padding:.35rem .6rem;border-radius:.6rem;border:1px solid #e5e7eb;background:#fff;cursor:pointer;font-size:.85rem}
-    .filter-btn.active{border-color:#0f766e;box-shadow:0 0 0 3px var(--ring)}
-    input[type="search"]{flex:1 1 280px;padding:.55rem .7rem;border:1px solid #e5e7eb;border-radius:.6rem}
-
-    .grid{display:grid;gap:16px}
-    @media(min-width:900px){.grid.cols-3{grid-template-columns:repeat(3,1fr)}.grid.cols-2{grid-template-columns:repeat(2,1fr)}}
-    .card{background:#fff;border:1px solid rgba(160,125,59,.25);border-radius:12px;padding:16px;transition:.2s;color:inherit;text-decoration:none;display:block}
-    .card:hover{border-color:rgba(160,125,59,.5);box-shadow:0 10px 26px rgba(0,0,0,.08);transform:translateY(-2px)}
-    .badge{display:inline-block;border:1px solid rgba(160,125,59,.35);color:var(--accent);font-family:'IBM Plex Mono',monospace;font-size:.72rem;padding:.15rem .45rem;border-radius:.4rem;margin-bottom:.35rem}
-
-    /* Flip cards */
-    .flip{perspective:1000px}
-    .flip-inner{position:relative;transform-style:preserve-3d;transition:transform .5s}
-    .flip:hover .flip-inner{transform:rotateY(180deg)}
-    .flip-face,.flip-back{backface-visibility:hidden;border-radius:12px;border:1px solid rgba(160,125,59,.25);padding:16px;background:#fff;height:100%}
-    .flip-back{position:absolute;inset:0;transform:rotateY(180deg)}
-    .meta-row{display:flex;gap:.5rem;align-items:center;flex-wrap:wrap;color:var(--muted);font-size:.85rem;margin:.25rem 0 .5rem}
-
-    .empty{padding:1rem;border:1px dashed #e5e7eb;border-radius:.75rem;background:#fafafa}
-
-    /* (Optional) Modal styles—kept for future detail view */
-    .modal{position:fixed;inset:0;background:rgba(0,0,0,.55);display:none}
-    .modal[aria-hidden="false"]{display:block}
-    .modal .inner{position:relative;max-width:900px;margin:4vh auto;background:#fff;border-radius:1rem;box-shadow:0 15px 35px rgba(0,0,0,.25);padding:1.25rem}
-    .modal .inner h1{margin:.4rem 0 0.35rem}
-    .modal .meta{color:var(--muted);font-size:.9rem}
-    .modal .divider{height:1px;background:#e5e7eb;margin:1rem 0}
-    .btn{display:inline-block;padding:.7rem 1.1rem;border-radius:.7rem;background:var(--ink);color:#fff;text-decoration:none;font-weight:700}
-    .btn:hover{filter:brightness(1.08)}
-    .btn.ghost{background:transparent;color:var(--ink);border:2px solid var(--ink)}
+    .filters-panel {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.8rem;
+      align-items: center;
+    }
+    .filters-panel input[type="search"] {
+      flex: 1 1 260px;
+      min-width: 220px;
+    }
   </style>
 </head>
-<body>
+<body class="page page--projects">
   <div class="shell">
-    <!-- Header -->
-    <header class="site-header">
+    <header class="site-header" aria-label="Site">
       <a class="brand" href="./index.html">Michael C. Barros</a>
-      <nav class="nav" aria-label="Main">
-        <a href="./about.html">About</a>
-        <a href="./books.html">Books</a>
-        <a id="nav-blog" href="https://mythonoesis.substack.com/" target="_blank" rel="noopener">Blog</a>
-        <a href="./projects.html" aria-current="page">Projects</a>
-        <a id="nav-research" href="#" target="_blank" rel="noopener">Research</a>
-        <a href="./contact.html">Contact</a>
+      <nav class="nav" aria-label="Primary">
+        <a class="nav__link" href="./about.html">About</a>
+        <a class="nav__link" href="./books.html">Books</a>
+        <a class="nav__link" id="nav-blog" href="https://mythonoesis.substack.com/" target="_blank" rel="noopener">Blog</a>
+        <a class="nav__link" href="./projects.html" aria-current="page">Projects</a>
+        <a class="nav__link" id="nav-research" href="#" target="_blank" rel="noopener">Research</a>
+        <a class="nav__link" href="./contact.html">Contact</a>
       </nav>
     </header>
 
-    <!-- Title -->
-    <section class="hero--compact">
-      <h1>Projects</h1>
-      <p class="muted">Active work, collaborations, and works-in-progress.</p>
-    </section>
+    <main>
+      <section class="page-header">
+        <span class="eyebrow">Projects</span>
+        <h1 class="page-title">Research collaborations &amp; works in progress</h1>
+        <p class="page-kicker">Active institutes, editorial projects, and media analyses mapping sacred imagination across contemporary culture.</p>
+      </section>
 
-    <div class="divider"></div>
+      <section class="section-card" aria-labelledby="proj-heading">
+        <div class="section-heading">
+          <h2 id="proj-heading">Browse projects</h2>
+          <span class="muted small">Hover cards for synopses; filter by status or theme.</span>
+        </div>
+        <div class="filters-panel" role="group" aria-label="Filters">
+          <div id="filters" class="filters"></div>
+          <input id="search" type="search" placeholder="Search title, tags, or summary…" aria-label="Search projects" />
+        </div>
+        <div id="projects-grid" class="grid cols-3" style="margin-top: 2rem;"></div>
+        <div id="empty" class="empty" style="display: none; margin-top: 1.5rem;">No projects match your filters yet—adjust the search or status.</div>
+      </section>
+    </main>
 
-    <!-- Filters + search -->
-    <section aria-labelledby="proj-heading">
-      <div class="section-head">
-        <h2 id="proj-heading">Browse</h2>
-        <span class="muted" style="font-size:.95rem">Filter by status or type; hover cards flip for details</span>
-      </div>
-
-      <div class="toolbar">
-        <div id="filters" class="filters" role="group" aria-label="Filters"></div>
-        <input id="search" type="search" placeholder="Search title, tags, summary…" aria-label="Search projects">
-      </div>
-
-      <div id="projects-grid" class="grid cols-3"></div>
-      <div id="empty" class="empty" style="display:none">No projects match your filters.</div>
-    </section>
-
-    <footer class="footer" style="text-align:center;color:var(--muted);margin-top:32px;font-size:.95rem">
+    <footer>
+      <p class="footer-tagline">Myth · Media · Imagination</p>
       © <span id="year"></span> Michael C. Barros
     </footer>
   </div>
 
-  <!-- Data then behavior -->
   <script defer src="./js/data/data.js"></script>
+  <script defer src="./js/nav.js"></script>
   <script defer src="./js/projects.js"></script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -1,19 +1,26 @@
-/* ===============================
-   Base site variables
-=============================== */
+@import url('https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&family=Playfair+Display:wght@500;600&display=swap');
+
 :root {
-  --ink: #111827;
-  --muted: #6b7280;
-  --accent: #0f766e;
-  --paper: #f7f4ee;
-  --card: #ffffff;
-  --ring: rgba(15, 118, 110, 0.25);
-  --brand: #243a7e; /* deep blue accent for buttons/links */
+  --ink: #f4f5fb;
+  --muted: #bfc6d8;
+  --accent: #6257a5;
+  --accent-strong: #4b3f82;
+  --accent-soft: rgba(98, 87, 165, 0.18);
+  --highlight: #d1b97a;
+  --paper: rgba(18, 22, 43, 0.92);
+  --paper-strong: rgba(22, 26, 52, 0.96);
+  --card: rgba(14, 18, 36, 0.85);
+  --card-soft: rgba(20, 24, 44, 0.7);
+  --border: rgba(118, 133, 179, 0.4);
+  --border-strong: rgba(161, 174, 214, 0.55);
+  --shadow-soft: 0 22px 48px rgba(3, 5, 14, 0.55);
+  --shadow-card: 0 16px 32px rgba(5, 7, 18, 0.6);
+  --shadow-inner: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+  --radius-lg: 18px;
+  --radius-md: 14px;
+  --radius-sm: 10px;
 }
 
-/* ===============================
-   Global defaults
-=============================== */
 *,
 *::before,
 *::after {
@@ -26,12 +33,38 @@ html {
 
 body {
   margin: 0;
+  font-family: 'Plus Jakarta Sans', 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
   font-size: 17px;
-  line-height: 1.75;
-  font-family: "EB Garamond", Georgia, serif;
-  background: var(--paper);
+  line-height: 1.7;
+  background: radial-gradient(circle at top left, rgba(61, 68, 110, 0.18), transparent 55%),
+    radial-gradient(circle at bottom right, rgba(51, 58, 94, 0.18), transparent 52%),
+    #05060f;
   color: var(--ink);
+  min-height: 100vh;
   -webkit-font-smoothing: antialiased;
+  position: relative;
+  overflow-x: hidden;
+}
+
+.shell {
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: 32px 20px 80px;
+  position: relative;
+}
+
+@media (min-width: 1200px) {
+  .shell {
+    padding-left: 32px;
+    padding-right: 32px;
+  }
+}
+
+header,
+main,
+footer {
+  position: relative;
+  z-index: 1;
 }
 
 img {
@@ -39,403 +72,591 @@ img {
   display: block;
 }
 
-/* ===============================
-   Typography
-=============================== */
 h1,
 h2,
-h3 {
-  letter-spacing: -0.015em;
-  font-weight: 600;
-  margin-top: 0;
-  margin-bottom: 0.5em;
-  line-height: 1.25;
+h3,
+h4 {
+  font-family: 'Playfair Display', 'Times New Roman', serif;
+  letter-spacing: -0.01em;
+  margin: 0 0 0.55em;
+  color: var(--ink);
 }
 
 h1 {
-  font-size: 2.6rem;
+  font-size: clamp(2.6rem, 4vw, 3.6rem);
+  line-height: 1.08;
 }
+
 h2 {
-  font-size: 1.8rem;
-  margin-top: 1.5rem;
+  font-size: clamp(1.9rem, 3vw, 2.4rem);
 }
+
 h3 {
-  font-size: 1.35rem;
+  font-size: clamp(1.3rem, 2.2vw, 1.6rem);
 }
 
 p {
-  margin-top: 0;
-  margin-bottom: 1em;
+  margin: 0 0 1.1em;
+  color: var(--muted);
 }
 
-/* ===============================
-   Links
-=============================== */
 a {
-  position: relative;
-  color: var(--brand);
+  color: inherit;
   text-decoration: none;
+  position: relative;
 }
+
 a::after {
-  content: "";
+  content: '';
   position: absolute;
   left: 0;
-  bottom: -2px;
+  bottom: -3px;
   width: 100%;
   height: 1px;
   background: currentColor;
   transform: scaleX(0);
   transform-origin: left;
-  transition: transform 0.25s ease;
+  transition: transform 0.22s ease;
+  opacity: 0.8;
 }
+
 a:hover::after {
   transform: scaleX(1);
 }
 
-/* ===============================
-   Buttons
-=============================== */
-.btn {
-  display: inline-block;
-  padding: 0.7rem 1.1rem;
-  border-radius: 0.7rem;
-  background: var(--ink);
-  color: #fff;
-  font-weight: 700;
-  text-decoration: none;
-  position: relative;
-  overflow: hidden;
-  transition: background 0.2s ease, transform 0.15s ease;
+a.btn::after,
+a.brand::after,
+a.nav__link::after {
+  display: none;
 }
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  padding: 0.75rem 1.4rem;
+  border-radius: 10px;
+  border: 1px solid var(--accent-strong);
+  font-weight: 600;
+  color: #f6f7fd;
+  background: var(--accent);
+  box-shadow: none;
+  transition: transform 0.18s ease, background-color 0.18s ease, border-color 0.18s ease;
+}
+
 .btn:hover {
   transform: translateY(-2px);
-  filter: brightness(1.08);
+  background: var(--accent-strong);
 }
-.btn:focus {
-  outline: none;
-  box-shadow: 0 0 0 3px rgba(36, 58, 126, 0.35);
+
+.btn:focus-visible {
+  outline: 2px solid var(--highlight);
+  outline-offset: 2px;
 }
+
 .btn.ghost {
   background: transparent;
-  border: 2px solid var(--brand);
-  color: var(--brand);
+  color: var(--ink);
+  border-color: var(--accent);
 }
+
 .btn.ghost:hover {
-  background: rgba(36, 58, 126, 0.08);
+  background: rgba(98, 87, 165, 0.12);
+  border-color: var(--accent-strong);
 }
 
-/* ===============================
-   Layout utilities
-=============================== */
-.shell {
-  max-width: 1060px;
-  margin: 0 auto;
-  padding: 20px 20px 48px;
-}
-.divider {
-  height: 1px;
-  background: #e5e7eb;
-  margin: 28px 0;
+.cta-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.9rem;
 }
 
-/* ===============================
-   Header & Nav
-=============================== */
-.site-header {
+.small {
+  font-size: 0.85rem;
+}
+
+.muted {
+  color: var(--muted);
+}
+
+.eyebrow {
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: rgba(193, 201, 222, 0.8);
+}
+
+.section-heading {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 10px 0;
+  gap: 1rem;
+  margin-bottom: 1.6rem;
 }
-.brand {
-  font-weight: 700;
-  text-decoration: none;
+
+.section-heading h2 {
+  margin: 0;
+}
+
+.section-heading .link {
+  font-weight: 600;
+  color: var(--highlight);
+}
+
+.section-heading .link:hover {
   color: var(--ink);
 }
+
+.divider {
+  width: 100%;
+  height: 1px;
+  margin: 48px 0;
+  background: rgba(118, 133, 179, 0.35);
+  border: none;
+}
+
+.site-header {
+  position: sticky;
+  top: 16px;
+  z-index: 20;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.6rem;
+  padding: 16px 22px;
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(94, 108, 155, 0.5);
+  background: rgba(12, 15, 32, 0.92);
+  box-shadow: 0 12px 26px rgba(3, 5, 12, 0.6);
+}
+
+.brand {
+  font-family: 'Playfair Display', 'Times New Roman', serif;
+  font-size: 1.2rem;
+  font-weight: 600;
+  color: var(--ink);
+}
+
 .nav {
   display: flex;
-  gap: 18px;
   flex-wrap: wrap;
+  gap: 0.85rem;
 }
-.nav a {
+
+.nav__link {
+  padding: 0.35rem 0.75rem;
+  border-radius: 8px;
+  color: rgba(193, 201, 222, 0.85);
+  font-weight: 500;
+  transition: color 0.18s ease, background 0.18s ease;
+}
+
+.nav__link[aria-current='page'] {
   color: var(--ink);
-  text-decoration: none;
-}
-.nav a:hover {
-  text-decoration: underline;
+  background: rgba(98, 87, 165, 0.18);
 }
 
-/* ===============================
-   Hero
-=============================== */
+.nav__link:hover {
+  color: var(--ink);
+  background: rgba(98, 87, 165, 0.12);
+}
+
+@media (max-width: 720px) {
+  .site-header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .nav {
+    justify-content: center;
+  }
+}
+
 .hero {
-  text-align: center;
-  padding: 60px 0 24px;
-  background: linear-gradient(180deg, #fdfcf9 0%, transparent 90%);
-}
-.hero h1 {
-  font-size: clamp(2rem, 4vw, 3rem);
-  margin-bottom: 0.5rem;
-}
-.hero p {
-  font-size: 1.1rem;
-  max-width: 720px;
-  margin: 0.5rem auto 1rem;
-  color: var(--muted);
-}
-.cta-row {
-  display: flex;
-  gap: 0.75rem;
-  justify-content: center;
-  flex-wrap: wrap;
-  margin-top: 14px;
+  position: relative;
+  margin-top: 72px;
+  display: grid;
+  gap: 3rem;
+  align-items: center;
 }
 
-/* ===============================
-   Cards
-=============================== */
+.hero__content {
+  max-width: 560px;
+}
+
+@media (min-width: 960px) {
+  .hero {
+    grid-template-columns: minmax(0, 1.1fr) minmax(220px, 0.9fr);
+  }
+}
+
+.hero__content h1 {
+  color: var(--ink);
+  max-width: 16ch;
+}
+
+.hero__tagline {
+  font-size: 1.15rem;
+  max-width: 620px;
+  color: rgba(201, 208, 226, 0.9);
+}
+
+.hero__meta {
+  margin-top: 1.4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.1rem;
+}
+
+.hero__meta .badge-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  font-size: 0.85rem;
+  color: rgba(193, 201, 222, 0.68);
+}
+
+.hero__media {
+  position: relative;
+  width: min(380px, 100%);
+  justify-self: center;
+}
+
+.hero__motif {
+  position: relative;
+  width: 100%;
+  padding-bottom: 100%;
+  border-radius: 50%;
+  border: 1px solid rgba(118, 133, 179, 0.5);
+  background: radial-gradient(circle, rgba(41, 46, 73, 0.65), transparent 64%);
+  overflow: hidden;
+}
+
+.hero__motif svg {
+  position: absolute;
+  inset: 12%;
+  width: 76%;
+  height: 76%;
+  opacity: 0.55;
+  stroke-width: 1;
+  stroke-linecap: round;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.3rem 0.85rem;
+  border-radius: 999px;
+  font-size: 0.76rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  border: 1px solid rgba(118, 133, 179, 0.45);
+  background: rgba(26, 30, 50, 0.7);
+  color: rgba(211, 216, 233, 0.85);
+}
+
 .grid {
   display: grid;
-  gap: 16px;
-}
-@media (min-width: 900px) {
-  .grid.cols-3 {
-    grid-template-columns: repeat(3, 1fr);
-  }
-  .grid.cols-2 {
-    grid-template-columns: repeat(2, 1fr);
-  }
-}
-.card {
-  background: var(--card);
-  border: 1px solid rgba(160, 125, 59, 0.25);
-  border-radius: 12px;
-  padding: 16px;
-  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
-  color: inherit;
-  text-decoration: none;
-  display: block;
-}
-.card:hover {
-  transform: translateY(-4px);
-  border-color: var(--brand);
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
-}
-.badge {
-  display: inline-block;
-  border: 1px solid rgba(160, 125, 59, 0.35);
-  color: var(--accent);
-  font-family: "IBM Plex Mono", monospace;
-  font-size: 0.72rem;
-  padding: 0.15rem 0.45rem;
-  border-radius: 0.4rem;
-  margin-bottom: 0.35rem;
+  gap: 22px;
 }
 
-/* ===============================
-   Flip cards
-=============================== */
-.flip {
-  perspective: 1000px;
+@media (min-width: 900px) {
+  .grid.cols-3 {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+  .grid.cols-2 {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
 }
+
+.card,
+.flip-face,
+.flip-back,
+.feature-box,
+.section-card,
+.info-card {
+  background: linear-gradient(180deg, rgba(20, 24, 45, 0.92), rgba(13, 17, 34, 0.92));
+  border: 1px solid rgba(94, 108, 155, 0.55);
+  border-radius: var(--radius-lg);
+  padding: 1.35rem;
+  box-shadow: var(--shadow-card);
+  color: var(--ink);
+  transition: transform 0.22s ease, border-color 0.22s ease, box-shadow 0.22s ease;
+}
+
+.card {
+  position: relative;
+  overflow: hidden;
+}
+
+.card > *:not(.card__motif) {
+  position: relative;
+  z-index: 1;
+}
+
+.card__motif {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 25% 20%, rgba(125, 113, 173, 0.18), transparent 65%),
+    radial-gradient(circle at 75% 80%, rgba(74, 83, 128, 0.2), transparent 60%);
+  opacity: 0.65;
+  pointer-events: none;
+  mix-blend-mode: screen;
+}
+
+.card__motif svg {
+  position: absolute;
+  top: 18%;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 72px;
+  height: 72px;
+  opacity: 0.25;
+  fill: none;
+  stroke: rgba(145, 153, 188, 0.5);
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.card:hover,
+.flip:hover .flip-face,
+.flip:hover .flip-back,
+.feature-box:hover,
+.section-card:hover,
+.info-card:hover {
+  border-color: rgba(209, 199, 158, 0.6);
+  transform: translateY(-3px);
+  box-shadow: 0 22px 46px rgba(5, 7, 18, 0.55);
+}
+
+.card h3 {
+  margin-top: 0.25rem;
+  margin-bottom: 0.4rem;
+}
+
+.feature-grid {
+  display: grid;
+  gap: 1.8rem;
+}
+
+@media (min-width: 960px) {
+  .feature-grid.two-col {
+    grid-template-columns: minmax(0, 360px) minmax(0, 1fr);
+  }
+}
+
+.feature-media {
+  position: relative;
+}
+
+.feature-media img {
+  border-radius: var(--radius-md);
+  box-shadow: 0 16px 36px rgba(5, 7, 18, 0.55);
+}
+
+.feature-media--avatar {
+  width: min(260px, 100%);
+  aspect-ratio: 1;
+  border-radius: 50%;
+  background: radial-gradient(circle at 50% 45%, rgba(68, 74, 112, 0.85), rgba(24, 28, 48, 0.95));
+  box-shadow: 0 24px 42px rgba(5, 7, 18, 0.55);
+  overflow: hidden;
+  position: relative;
+}
+
+.feature-media--avatar::after {
+  content: '';
+  position: absolute;
+  inset: 18%;
+  border-radius: 50%;
+  border: 1px solid rgba(118, 133, 179, 0.35);
+  background: conic-gradient(from 45deg, transparent 0 25%, rgba(93, 99, 138, 0.45) 25% 30%, transparent 30% 55%, rgba(93, 99, 138, 0.45) 55% 60%, transparent 60%);
+  opacity: 0.55;
+}
+
+.feature-body,
+.feature-copy,
+.book-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+  max-width: 560px;
+}
+
+.book-cover {
+  width: 100%;
+  border-radius: var(--radius-md);
+  box-shadow: 0 18px 36px rgba(5, 7, 18, 0.55);
+}
+
+.book-copy .book-desc p {
+  margin-bottom: 0.85rem;
+  color: var(--muted);
+}
+
+.flip {
+  perspective: 1400px;
+}
+
 .flip-inner {
   position: relative;
   transform-style: preserve-3d;
-  transition: transform 0.5s;
+  transition: transform 0.55s ease;
+  min-height: 220px;
 }
+
 .flip:hover .flip-inner {
   transform: rotateY(180deg);
 }
+
 .flip-face,
 .flip-back {
   backface-visibility: hidden;
-  border-radius: 12px;
-  border: 1px solid rgba(160, 125, 59, 0.25);
-  padding: 16px;
-  background: #fff;
-  height: 100%;
-}
-.flip-back {
   position: absolute;
   inset: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+
+.flip-back {
   transform: rotateY(180deg);
 }
 
-/* ===============================
-   Filters / chips
-=============================== */
-.chip {
-  display: inline-block;
-  padding: 0.35rem 0.6rem;
-  border-radius: 0.6rem;
-  border: 1px solid #e5e7eb;
-  background: #fff;
-  cursor: pointer;
-  font-size: 0.85rem;
-  transition: background 0.2s, color 0.2s, transform 0.15s;
+.empty {
+  border-radius: var(--radius-md);
+  border: 1px dashed rgba(118, 133, 179, 0.5);
+  padding: 1.2rem;
+  text-align: center;
+  background: rgba(18, 22, 44, 0.75);
+  color: var(--muted);
 }
-.chip:hover {
+
+footer {
+  margin-top: 72px;
+  text-align: center;
+  color: rgba(198, 205, 224, 0.75);
+  font-size: 0.95rem;
+}
+
+.footer-tagline {
+  margin-bottom: 0.5rem;
+  font-size: 0.85rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(193, 201, 222, 0.82);
+}
+
+code {
+  font-family: 'Fira Code', 'SFMono-Regular', Consolas, 'Liberation Mono', monospace;
+  font-size: 0.9rem;
+  color: rgba(233, 232, 245, 0.95);
+  background: rgba(20, 24, 44, 0.85);
+  border: 1px solid rgba(118, 133, 179, 0.5);
+  padding: 0.25rem 0.45rem;
+  border-radius: 8px;
+}
+
+input[type='search'],
+input[type='text'],
+button {
+  font: inherit;
+}
+
+input[type='search'],
+textarea {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(118, 133, 179, 0.5);
+  background: rgba(12, 16, 34, 0.85);
+  color: var(--ink);
+  box-shadow: var(--shadow-inner);
+}
+
+input[type='search']:focus,
+textarea:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(98, 87, 165, 0.3);
+}
+
+.filter-btn {
+  padding: 0.45rem 0.85rem;
+  border-radius: 999px;
+  border: 1px solid rgba(118, 133, 179, 0.45);
+  background: rgba(22, 26, 48, 0.85);
+  color: rgba(209, 215, 232, 0.85);
+  cursor: pointer;
+  transition: transform 0.18s ease, border-color 0.18s ease, background 0.18s ease;
+}
+
+.filter-btn:hover {
+  border-color: var(--accent);
   transform: translateY(-2px);
 }
-.chip.active {
-  background: var(--brand);
-  color: #fff;
-  border-color: var(--brand);
+
+.filter-btn.active {
+  background: var(--accent);
+  border-color: var(--accent-strong);
+  color: #f6f7fd;
+  box-shadow: none;
 }
 
-/* ===============================
-   Book hero
-=============================== */
-.book-hero {
-  display: grid;
-  gap: 18px;
-  align-items: center;
+.page-header {
+  margin-top: 72px;
+  margin-bottom: 36px;
 }
-@media (min-width: 900px) {
-  .book-hero {
-    grid-template-columns: 160px 1fr;
+
+.page-header .page-title {
+  font-size: clamp(2rem, 4vw, 3rem);
+  color: var(--ink);
+}
+
+.page-header .page-kicker {
+  font-size: 1.05rem;
+  max-width: 720px;
+}
+
+.detail-grid {
+  display: grid;
+  gap: 24px;
+}
+
+@media (min-width: 960px) {
+  .detail-grid.two-col {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
-.book-cover {
-  width: 100%;
-  height: auto;
-  border-radius: 8px;
-  box-shadow: 0 8px 22px rgba(0, 0, 0, 0.08);
-}
 
-/* ===============================
-   Reviews
-=============================== */
-.reviews {
-  display: grid;
-  gap: 12px;
-}
-@media (min-width: 900px) {
-  .reviews {
-    grid-template-columns: repeat(3, 1fr);
-  }
-}
-.review {
-  background: #fff;
-  border: 1px solid rgba(160, 125, 59, 0.25);
-  border-radius: 10px;
-  padding: 12px;
-}
-.review small {
-  color: var(--muted);
-}
-
-/* ===============================
-   Modal
-=============================== */
-.modal {
-  background: rgba(0, 0, 0, 0.6);
+.info-card {
   display: flex;
-  justify-content: center;
-  align-items: flex-start;
-  padding: 4vh 1rem;
-  opacity: 0;
-  pointer-events: none;
-  transition: opacity 0.25s ease;
+  flex-direction: column;
+  gap: 0.75rem;
 }
-.modal.open {
-  opacity: 1;
-  pointer-events: auto;
+
+.meta-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem 0.8rem;
+  font-size: 0.85rem;
+  color: rgba(193, 201, 222, 0.68);
 }
-.modal .inner {
-  background: #fff;
-  border-radius: 1rem;
-  max-width: 880px;
-  padding: 2rem;
-  box-shadow: 0 20px 45px rgba(0, 0, 0, 0.35);
-  animation: zoomIn 0.25s ease;
+
+address {
+  font-style: normal;
 }
-@keyframes zoomIn {
-  from {
-    transform: scale(0.92) translateY(20px);
-    opacity: 0;
-  }
-  to {
-    transform: scale(1) translateY(0);
-    opacity: 1;
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+    scroll-behavior: auto !important;
   }
 }
-
-/* ===============================
-   Footer
-=============================== */
-.footer {
-  padding: 32px 0;
-  text-align: center;
-  font-family: "IBM Plex Mono", monospace;
-  font-size: 0.9rem;
-  color: var(--muted);
-  border-top: 1px solid rgba(0, 0, 0, 0.08);
-}
-/* ===== Jump Kit: layout + components ===== */
-
-/* Palette tune */
-:root{
-  --brand:#0f766e;           /* accent */
-  --ink:#121212;
-  --muted:#6b7280;
-  --paper:#F7F4EE;
-  --card:#ffffff;
-  --ring:rgba(15,118,110,.25);
-}
-
-/* Container */
-.shell{max-width:1160px;margin:0 auto;padding:24px 20px 56px}
-
-/* Sticky clean header */
-.site-header{position:sticky;top:0;background:var(--paper);z-index:50;
-  display:flex;align-items:center;justify-content:space-between;padding:10px 0;
-  border-bottom:1px solid rgba(0,0,0,.06);backdrop-filter:saturate(1.2) blur(4px)}
-.brand{font-weight:800;letter-spacing:-.01em}
-.nav{display:flex;gap:20px}
-.nav a{color:var(--ink);text-decoration:none}
-.nav a:hover{text-decoration:underline}
-
-/* Big hero, darker weight like JP */
-.hero{padding:56px 0 28px;text-align:center;background:
-  radial-gradient(1200px 400px at 50% -100px, #ffffff 0%, transparent 70%)}
-.hero h1{font-size:clamp(2.2rem,4vw,3rem);letter-spacing:-.015em}
-.hero .tagline{color:var(--muted);font-size:1.08rem}
-
-/* Buttons – slightly chunkier */
-.btn{display:inline-block;padding:.78rem 1.15rem;border-radius:.8rem;
-  background:var(--ink);color:#fff;text-decoration:none;font-weight:700;
-  transition:transform .15s ease, box-shadow .15s ease}
-.btn:hover{transform:translateY(-2px);box-shadow:0 8px 18px rgba(0,0,0,.12)}
-.btn.ghost{background:transparent;color:var(--ink);border:2px solid var(--ink)}
-.btn.ghost:hover{background:rgba(0,0,0,.04)}
-
-/* Section header */
-.section-head{display:flex;align-items:baseline;justify-content:space-between;margin:0 0 12px}
-.section-head h2{margin:0;font-size:1.35rem}
-
-/* Feature box (book hero card) */
-.feature-box{background:var(--card);border:1px solid rgba(0,0,0,.08);border-radius:14px;
-  box-shadow:0 10px 28px rgba(0,0,0,.08);padding:18px}
-.feature-grid{display:grid;gap:20px;align-items:stretch}
-@media(min-width:980px){.feature-grid{grid-template-columns:minmax(280px,360px) 1fr}}
-.feature-media{border-radius:12px;overflow:hidden;box-shadow:0 10px 28px rgba(0,0,0,.10)}
-.feature-media img{display:block;width:100%;height:100%;object-fit:cover}
-.feature-body h3{margin:.2rem 0 .4rem;font-size:1.6rem}
-.feature-body .muted{margin:.4rem 0 .6rem;color:var(--muted)}
-.feature-body .cta-row{justify-content:flex-start;margin:.6rem 0 .4rem}
-.feature-body .desc{margin-top:.4rem}
-.feature-body .desc p{margin:.58rem 0;line-height:1.72}
-
-/* Card grid (projects) */
-.grid{display:grid;gap:16px}
-@media(min-width:900px){.grid.cols-3{grid-template-columns:repeat(3,1fr)}}
-.card{background:#fff;border:1px solid rgba(0,0,0,.08);border-radius:12px;padding:16px;
-  transition:transform .15s ease, box-shadow .15s ease, border-color .15s ease}
-.card:hover{transform:translateY(-2px);box-shadow:0 10px 24px rgba(0,0,0,.10);border-color:rgba(0,0,0,.18)}
-.badge{display:inline-block;border:1px solid rgba(15,118,110,.35);color:var(--brand);
-  font-family:ui-monospace, SFMono-Regular, Menlo, monospace;font-size:.72rem;padding:.18rem .46rem;border-radius:.5rem}
-
-/* Divider + footer */
-.divider{height:1px;background:#e5e7eb;margin:28px 0}
-.footer{padding:36px 0;text-align:center;color:var(--muted);font-size:.95rem}


### PR DESCRIPTION
## Summary
- Replace the site’s visual system with a navy-and-plum palette, solid buttons, watermark card motifs, and a footer tagline to reinforce an academic tone.
- Update the homepage hero, featured book, and projects grid to use the new cosmogram motif, neutral badges, refreshed copy, and subdued fallback artwork.
- Revise the About, Books, Projects, and Contact pages with new scholarly copy, iconography, and consistent call-to-actions while updating scripts for motif support and tagline messaging.

## Testing
- Not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68e2ec863e888330a54c69015715c046