### PR TITLE
Refine profile labels and email placeholder

### DIFF
--- a/about.html
+++ b/about.html
@@ -123,7 +123,7 @@
         <div class="cta-row" role="group" aria-label="Primary actions">
           <a class="btn" href="./books.html">Books</a>
           <a class="btn" href="./projects.html">Projects</a>
-          <a class="btn" href="./contact.html#cv">Curriculum Vitae</a>
+          <a class="btn" href="./contact.html#cv">Profiles</a>
         </div>
       </section>
 
@@ -264,9 +264,8 @@
         </div>
         <div class="detail-grid two-col">
           <article class="info-card">
-            <h3>Research profiles</h3>
-            <p>External publications, preprints, and works-in-progress.</p>
-            <a class="btn" id="about-research" href="#" target="_blank" rel="noopener">Open Research</a>
+            <h3>Profiles</h3>
+            <a class="btn" id="about-research" href="#" target="_blank" rel="noopener">Open profiles</a>
           </article>
           <article class="info-card">
             <h3>Substack</h3>
@@ -280,11 +279,9 @@
     <footer>
       <p class="footer-tagline">Religion · Media · Imagination</p>
       <nav class="footer-links" aria-label="Secondary">
-        <a href="./assets/docs/michael-c-barros-cv.pdf" target="_blank" rel="noopener">CV (PDF)</a>
         <a href="https://mythonoesis.substack.com/" target="_blank" rel="noopener">Substack</a>
-        <a href="https://github.com/michaelcbarros" target="_blank" rel="noopener">GitHub</a>
-        <a href="https://orcid.org/" target="_blank" rel="noopener">ORCID</a>
-        <a href="https://independent.academia.edu/MichaelBarros" target="_blank" rel="noopener">Academia.edu</a>
+        <a href="https://orcid.org/0000-0001-5462-8926" target="_blank" rel="noopener">ORCID</a>
+        <a href="https://national.academia.edu/MichaelBarros" target="_blank" rel="noopener">Academia.edu</a>
       </nav>
       © <span id="year"></span> Michael C. Barros
     </footer>

--- a/books.html
+++ b/books.html
@@ -82,6 +82,7 @@
               </div>
             </div>
           </div>
+          <button type="button" class="btn ghost" id="book-toggle" aria-expanded="false" aria-controls="book-extras" style="margin-top: 1.5rem; display: none;">Read more</button>
           <div id="book-extras" class="detail-grid" style="margin-top: 2rem; display: none;">
             <div class="book-copy" id="book-desc"></div>
             <div class="detail-grid" id="book-blurbs"></div>
@@ -100,11 +101,9 @@
     <footer>
       <p class="footer-tagline">Religion · Media · Imagination</p>
       <nav class="footer-links" aria-label="Secondary">
-        <a href="./assets/docs/michael-c-barros-cv.pdf" target="_blank" rel="noopener">CV (PDF)</a>
         <a href="https://mythonoesis.substack.com/" target="_blank" rel="noopener">Substack</a>
-        <a href="https://github.com/michaelcbarros" target="_blank" rel="noopener">GitHub</a>
-        <a href="https://orcid.org/" target="_blank" rel="noopener">ORCID</a>
-        <a href="https://independent.academia.edu/MichaelBarros" target="_blank" rel="noopener">Academia.edu</a>
+        <a href="https://orcid.org/0000-0001-5462-8926" target="_blank" rel="noopener">ORCID</a>
+        <a href="https://national.academia.edu/MichaelBarros" target="_blank" rel="noopener">Academia.edu</a>
       </nav>
       © <span id="year"></span> Michael C. Barros
     </footer>
@@ -149,6 +148,7 @@
       `;
 
       const extras = document.getElementById('book-extras');
+      const toggleBtn = document.getElementById('book-toggle');
       const descEl = document.getElementById('book-desc');
       const blurbsEl = document.getElementById('book-blurbs');
 
@@ -171,8 +171,25 @@
         `).join('');
       }
 
-      if ((paragraphs.length || reviews.length) && extras) {
-        extras.style.display = 'grid';
+      const hasExtras = (paragraphs.length || reviews.length) > 0;
+
+      if (hasExtras && toggleBtn && extras) {
+        const setExpanded = (expanded) => {
+          extras.style.display = expanded ? 'grid' : 'none';
+          toggleBtn.textContent = expanded ? 'Read less' : 'Read more';
+          toggleBtn.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+          extras.setAttribute('aria-hidden', expanded ? 'false' : 'true');
+        };
+
+        toggleBtn.style.display = 'inline-flex';
+        setExpanded(false);
+
+        toggleBtn.addEventListener('click', () => {
+          const isExpanded = toggleBtn.getAttribute('aria-expanded') === 'true';
+          setExpanded(!isExpanded);
+        });
+      } else if (toggleBtn) {
+        toggleBtn.style.display = 'none';
       }
 
       const others = books.filter(b => b !== featured);

--- a/contact.html
+++ b/contact.html
@@ -55,7 +55,7 @@
           <h2>Email</h2>
           <p class="muted">Include event context, proposed dates, and format in your initial message.</p>
           <div class="contact-actions">
-            <code id="addr">barrostheology@gmail.com</code>
+            <code id="addr">hello@example.com</code>
             <button id="copy" class="btn ghost" type="button">Copy</button>
             <a id="mailto" class="btn" href="#">Compose email</a>
           </div>
@@ -67,15 +67,12 @@
         </article>
 
         <article class="section-card" id="cv">
-          <h2>Curriculum vitae &amp; profiles</h2>
-          <p class="muted">Download the current CV or connect via research platforms.</p>
+          <h2>Profiles</h2>
           <ul class="link-list">
-            <li><a href="./assets/docs/michael-c-barros-cv.pdf" target="_blank" rel="noopener">Curriculum Vitae (PDF)</a></li>
             <li><a href="https://www.researchgate.net/profile/Michael-Barros-2" target="_blank" rel="noopener">ResearchGate</a></li>
-            <li><a href="https://mythonoesis.substack.com/" target="_blank" rel="noopener">Substack — Mythonoesis</a></li>
-            <li><a href="https://github.com/michaelcbarros" target="_blank" rel="noopener">GitHub</a></li>
-            <li><a href="https://orcid.org/" target="_blank" rel="noopener">ORCID (profile forthcoming)</a></li>
-            <li><a href="https://independent.academia.edu/MichaelBarros" target="_blank" rel="noopener">Academia.edu</a></li>
+            <li><a href="https://mythonoesis.substack.com/" target="_blank" rel="noopener">Substack</a></li>
+            <li><a href="https://orcid.org/0000-0001-5462-8926" target="_blank" rel="noopener">ORCID</a></li>
+            <li><a href="https://national.academia.edu/MichaelBarros" target="_blank" rel="noopener">Academia.edu</a></li>
           </ul>
         </article>
       </section>
@@ -84,11 +81,9 @@
     <footer>
       <p class="footer-tagline">Religion · Media · Imagination</p>
       <nav class="footer-links" aria-label="Secondary">
-        <a href="./assets/docs/michael-c-barros-cv.pdf" target="_blank" rel="noopener">CV (PDF)</a>
         <a href="https://mythonoesis.substack.com/" target="_blank" rel="noopener">Substack</a>
-        <a href="https://github.com/michaelcbarros" target="_blank" rel="noopener">GitHub</a>
-        <a href="https://orcid.org/" target="_blank" rel="noopener">ORCID</a>
-        <a href="https://independent.academia.edu/MichaelBarros" target="_blank" rel="noopener">Academia.edu</a>
+        <a href="https://orcid.org/0000-0001-5462-8926" target="_blank" rel="noopener">ORCID</a>
+        <a href="https://national.academia.edu/MichaelBarros" target="_blank" rel="noopener">Academia.edu</a>
       </nav>
       © <span id="year"></span> Michael C. Barros
     </footer>
@@ -100,17 +95,18 @@
     window.addEventListener('DOMContentLoaded', () => {
       const LINKS = (window.SITE_DATA && window.SITE_DATA.links) || window.LINKS || {};
       const EMAIL = (window.SITE_DATA && window.SITE_DATA.contact && window.SITE_DATA.contact.email) || 'barrostheology@gmail.com';
+      const PLACEHOLDER = 'hello@example.com';
 
       const blog = document.getElementById('nav-blog');
       if (blog) blog.href = LINKS.blog || 'https://mythonoesis.substack.com/';
       const research = document.getElementById('nav-research');
       if (research) research.href = LINKS.research || 'https://www.researchgate.net/';
 
-      const addrEl = document.getElementById('addr');
-      if (addrEl) addrEl.textContent = EMAIL;
-
       const mailto = document.getElementById('mailto');
       if (mailto) mailto.href = `mailto:${EMAIL}`;
+
+      const addr = document.getElementById('addr');
+      if (addr) addr.textContent = PLACEHOLDER;
 
       const copy = document.getElementById('copy');
       if (copy) {

--- a/index.html
+++ b/index.html
@@ -153,7 +153,7 @@
             <div class="feature-body">
               <span class="eyebrow">About Michael</span>
               <h3 id="bio-heading">Interdisciplinary scholar of religion, imagination, and media</h3>
-              <p class="muted">Based in Southern California, Michael C. Barros examines how sacred imagination is structured within games, film, and speculative fiction, drawing on theology, grounded cognition, and cultural history.</p>
+              <p class="muted">Michael C. Barros examines how sacred imagination is structured within games, film, and speculative fiction, drawing on theology, grounded cognition, and cultural history.</p>
               <p class="muted">He teaches across humanities and social science curricula and publishes on topics including Philip K. Dick, The Legend of Zelda, and religious experience in interactive worlds.</p>
               <div class="cta-row">
                 <a class="btn ghost" href="./about.html">Research overview</a>
@@ -168,11 +168,9 @@
     <footer>
       <p class="footer-tagline">Religion · Media · Imagination</p>
       <nav class="footer-links" aria-label="Secondary">
-        <a href="./assets/docs/michael-c-barros-cv.pdf" target="_blank" rel="noopener">CV (PDF)</a>
         <a href="https://mythonoesis.substack.com/" target="_blank" rel="noopener">Substack</a>
-        <a href="https://github.com/michaelcbarros" target="_blank" rel="noopener">GitHub</a>
-        <a href="https://orcid.org/" target="_blank" rel="noopener">ORCID</a>
-        <a href="https://independent.academia.edu/MichaelBarros" target="_blank" rel="noopener">Academia.edu</a>
+        <a href="https://orcid.org/0000-0001-5462-8926" target="_blank" rel="noopener">ORCID</a>
+        <a href="https://national.academia.edu/MichaelBarros" target="_blank" rel="noopener">Academia.edu</a>
       </nav>
       © <span id="year"></span> Michael C. Barros
     </footer>

--- a/projects.html
+++ b/projects.html
@@ -57,11 +57,9 @@
     <footer>
       <p class="footer-tagline">Religion · Media · Imagination</p>
       <nav class="footer-links" aria-label="Secondary">
-        <a href="./assets/docs/michael-c-barros-cv.pdf" target="_blank" rel="noopener">CV (PDF)</a>
         <a href="https://mythonoesis.substack.com/" target="_blank" rel="noopener">Substack</a>
-        <a href="https://github.com/michaelcbarros" target="_blank" rel="noopener">GitHub</a>
-        <a href="https://orcid.org/" target="_blank" rel="noopener">ORCID</a>
-        <a href="https://independent.academia.edu/MichaelBarros" target="_blank" rel="noopener">Academia.edu</a>
+        <a href="https://orcid.org/0000-0001-5462-8926" target="_blank" rel="noopener">ORCID</a>
+        <a href="https://national.academia.edu/MichaelBarros" target="_blank" rel="noopener">Academia.edu</a>
       </nav>
       © <span id="year"></span> Michael C. Barros
     </footer>


### PR DESCRIPTION
## Summary
- add a Read more button to the featured book section on the books page
- defer rendering of the extended description and review content until the section is expanded
- provide accessible state updates so the button reflects whether the details are expanded
- update research profile links to the new ORCID and Academia.edu URLs while removing the CV and GitHub references
- hide the email address in the contact preview while keeping copy and compose actions available
- rename research profile references to “Profiles,” remove the descriptive blurb, and present a neutral placeholder email instead of the hidden label

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e30973b5d48330968481d0f8f59a18