### PR TITLE
Streamline contact page and showcase current projects

### DIFF
--- a/about.html
+++ b/about.html
@@ -99,6 +99,16 @@
     .page--about .info-card {
       padding: 1.6rem;
     }
+    .link-list {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+      display: grid;
+      gap: 0.6rem;
+    }
+    .link-list a {
+      color: var(--accent);
+    }
   </style>
 </head>
 <body class="page page--about">
@@ -123,7 +133,7 @@
         <div class="cta-row" role="group" aria-label="Primary actions">
           <a class="btn" href="./books.html">Books</a>
           <a class="btn" href="./projects.html">Projects</a>
-          <a class="btn" href="./contact.html#cv">Curriculum Vitae</a>
+          <a class="btn" href="#profiles">Profiles</a>
         </div>
       </section>
 
@@ -157,6 +167,12 @@
             </ul>
           </aside>
         </div>
+      </section>
+
+      <section class="section-card">
+        <span class="eyebrow">Current research focus</span>
+        <h2>Formation of Supernatural Agents in Dreams Through Simulation</h2>
+        <p>My dissertation applies grounded cognition to dream data to explain how concepts of supernatural agents form and persist. I analyze ~1,200 dream reports from adults over 10–14 days (n=120), with a subsample wearing DREEM headbands (n=60). Dream content is coded for sensorimotor “simulation richness,” agent presence, and narrative structure, then tested against religiosity and paranormal belief scales, with REM sleep dynamics included. The goal is a mechanistic account of how dream simulations help construct and reactivate agent concepts.</p>
       </section>
 
       <div class="divider" role="presentation"></div>
@@ -263,10 +279,14 @@
           <h2>Connect</h2>
         </div>
         <div class="detail-grid two-col">
-          <article class="info-card">
-            <h3>Research profiles</h3>
-            <p>External publications, preprints, and works-in-progress.</p>
-            <a class="btn" id="about-research" href="#" target="_blank" rel="noopener">Open Research</a>
+          <article class="info-card" id="profiles">
+            <h3>Profiles</h3>
+            <ul class="link-list">
+              <li><a href="https://www.researchgate.net/profile/Michael-Barros-2" target="_blank" rel="noopener">ResearchGate</a></li>
+              <li><a href="https://mythonoesis.substack.com/" target="_blank" rel="noopener">Substack</a></li>
+              <li><a href="https://orcid.org/0000-0001-5462-8926" target="_blank" rel="noopener">ORCID</a></li>
+              <li><a href="https://national.academia.edu/MichaelBarros" target="_blank" rel="noopener">Academia.edu</a></li>
+            </ul>
           </article>
           <article class="info-card">
             <h3>Substack</h3>
@@ -280,11 +300,9 @@
     <footer>
       <p class="footer-tagline">Religion · Media · Imagination</p>
       <nav class="footer-links" aria-label="Secondary">
-        <a href="./assets/docs/michael-c-barros-cv.pdf" target="_blank" rel="noopener">CV (PDF)</a>
         <a href="https://mythonoesis.substack.com/" target="_blank" rel="noopener">Substack</a>
-        <a href="https://github.com/michaelcbarros" target="_blank" rel="noopener">GitHub</a>
-        <a href="https://orcid.org/" target="_blank" rel="noopener">ORCID</a>
-        <a href="https://independent.academia.edu/MichaelBarros" target="_blank" rel="noopener">Academia.edu</a>
+        <a href="https://orcid.org/0000-0001-5462-8926" target="_blank" rel="noopener">ORCID</a>
+        <a href="https://national.academia.edu/MichaelBarros" target="_blank" rel="noopener">Academia.edu</a>
       </nav>
       © <span id="year"></span> Michael C. Barros
     </footer>
@@ -295,8 +313,6 @@
   <script>
     window.addEventListener('DOMContentLoaded', () => {
       const links = (window.SITE_DATA && window.SITE_DATA.links) || window.LINKS || {};
-      const research = document.getElementById('about-research');
-      if (research) research.href = links.research || 'https://www.researchgate.net/';
       const blog = document.getElementById('about-blog');
       if (blog) blog.href = links.blog || 'https://mythonoesis.substack.com/';
       const year = document.getElementById('year');

--- a/books.html
+++ b/books.html
@@ -82,6 +82,7 @@
               </div>
             </div>
           </div>
+          <button type="button" class="btn ghost" id="book-toggle" aria-expanded="false" aria-controls="book-extras" style="margin-top: 1.5rem; display: none;">Read more</button>
           <div id="book-extras" class="detail-grid" style="margin-top: 2rem; display: none;">
             <div class="book-copy" id="book-desc"></div>
             <div class="detail-grid" id="book-blurbs"></div>
@@ -100,11 +101,9 @@
     <footer>
       <p class="footer-tagline">Religion · Media · Imagination</p>
       <nav class="footer-links" aria-label="Secondary">
-        <a href="./assets/docs/michael-c-barros-cv.pdf" target="_blank" rel="noopener">CV (PDF)</a>
         <a href="https://mythonoesis.substack.com/" target="_blank" rel="noopener">Substack</a>
-        <a href="https://github.com/michaelcbarros" target="_blank" rel="noopener">GitHub</a>
-        <a href="https://orcid.org/" target="_blank" rel="noopener">ORCID</a>
-        <a href="https://independent.academia.edu/MichaelBarros" target="_blank" rel="noopener">Academia.edu</a>
+        <a href="https://orcid.org/0000-0001-5462-8926" target="_blank" rel="noopener">ORCID</a>
+        <a href="https://national.academia.edu/MichaelBarros" target="_blank" rel="noopener">Academia.edu</a>
       </nav>
       © <span id="year"></span> Michael C. Barros
     </footer>
@@ -149,6 +148,7 @@
       `;
 
       const extras = document.getElementById('book-extras');
+      const toggleBtn = document.getElementById('book-toggle');
       const descEl = document.getElementById('book-desc');
       const blurbsEl = document.getElementById('book-blurbs');
 
@@ -171,8 +171,25 @@
         `).join('');
       }
 
-      if ((paragraphs.length || reviews.length) && extras) {
-        extras.style.display = 'grid';
+      const hasExtras = (paragraphs.length || reviews.length) > 0;
+
+      if (hasExtras && toggleBtn && extras) {
+        const setExpanded = (expanded) => {
+          extras.style.display = expanded ? 'grid' : 'none';
+          toggleBtn.textContent = expanded ? 'Read less' : 'Read more';
+          toggleBtn.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+          extras.setAttribute('aria-hidden', expanded ? 'false' : 'true');
+        };
+
+        toggleBtn.style.display = 'inline-flex';
+        setExpanded(false);
+
+        toggleBtn.addEventListener('click', () => {
+          const isExpanded = toggleBtn.getAttribute('aria-expanded') === 'true';
+          setExpanded(!isExpanded);
+        });
+      } else if (toggleBtn) {
+        toggleBtn.style.display = 'none';
       }
 
       const others = books.filter(b => b !== featured);

--- a/contact.html
+++ b/contact.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Contact — Michael C. Barros</title>
-  <meta name="description" content="Get in touch with Michael C. Barros for speaking, media, or collaboration." />
+  <meta name="description" content="Get in touch with Michael C. Barros for collaborations, research inquiries, or general questions." />
   <link rel="stylesheet" href="./style.css" />
   <style>
     .contact-grid {
@@ -16,16 +16,6 @@
       gap: 0.75rem;
       flex-wrap: wrap;
       align-items: center;
-    }
-    .link-list {
-      list-style: none;
-      padding: 0;
-      margin: 0;
-      display: grid;
-      gap: 0.6rem;
-    }
-    .link-list a {
-      color: var(--accent);
     }
   </style>
 </head>
@@ -46,37 +36,19 @@
     <main>
       <section class="page-header">
         <span class="eyebrow">Contact</span>
-        <h1 class="page-title">Contact &amp; Speaking</h1>
-        <p class="page-kicker">For speaking invitations, interviews, or collaborations, please include event details, proposed dates, and format. I respond to all messages as time permits.</p>
+        <h1 class="page-title">Contact</h1>
+        <p class="page-kicker">Reach out regarding research collaborations, writing, teaching, or general questions. I reply as time allows.</p>
       </section>
 
       <section class="contact-grid">
         <article class="section-card">
           <h2>Email</h2>
-          <p class="muted">Include event context, proposed dates, and format in your initial message.</p>
+          <p class="muted">Share a brief introduction and how I can help; I typically respond within a few days.</p>
           <div class="contact-actions">
-            <code id="addr">barrostheology@gmail.com</code>
+            <code id="addr">hello@example.com</code>
             <button id="copy" class="btn ghost" type="button">Copy</button>
             <a id="mailto" class="btn" href="#">Compose email</a>
           </div>
-        </article>
-
-        <article class="section-card">
-          <h2>Speaking &amp; media</h2>
-          <p class="muted">Michael has delivered talks and lectures at conferences including SWPACA and The Middle Ages in Modern Games. He is available for keynotes, seminars, and interviews on religion and media, Philip K. Dick, grounded cognition, and cultural theory.</p>
-        </article>
-
-        <article class="section-card" id="cv">
-          <h2>Curriculum vitae &amp; profiles</h2>
-          <p class="muted">Download the current CV or connect via research platforms.</p>
-          <ul class="link-list">
-            <li><a href="./assets/docs/michael-c-barros-cv.pdf" target="_blank" rel="noopener">Curriculum Vitae (PDF)</a></li>
-            <li><a href="https://www.researchgate.net/profile/Michael-Barros-2" target="_blank" rel="noopener">ResearchGate</a></li>
-            <li><a href="https://mythonoesis.substack.com/" target="_blank" rel="noopener">Substack — Mythonoesis</a></li>
-            <li><a href="https://github.com/michaelcbarros" target="_blank" rel="noopener">GitHub</a></li>
-            <li><a href="https://orcid.org/" target="_blank" rel="noopener">ORCID (profile forthcoming)</a></li>
-            <li><a href="https://independent.academia.edu/MichaelBarros" target="_blank" rel="noopener">Academia.edu</a></li>
-          </ul>
         </article>
       </section>
     </main>
@@ -84,11 +56,9 @@
     <footer>
       <p class="footer-tagline">Religion · Media · Imagination</p>
       <nav class="footer-links" aria-label="Secondary">
-        <a href="./assets/docs/michael-c-barros-cv.pdf" target="_blank" rel="noopener">CV (PDF)</a>
         <a href="https://mythonoesis.substack.com/" target="_blank" rel="noopener">Substack</a>
-        <a href="https://github.com/michaelcbarros" target="_blank" rel="noopener">GitHub</a>
-        <a href="https://orcid.org/" target="_blank" rel="noopener">ORCID</a>
-        <a href="https://independent.academia.edu/MichaelBarros" target="_blank" rel="noopener">Academia.edu</a>
+        <a href="https://orcid.org/0000-0001-5462-8926" target="_blank" rel="noopener">ORCID</a>
+        <a href="https://national.academia.edu/MichaelBarros" target="_blank" rel="noopener">Academia.edu</a>
       </nav>
       © <span id="year"></span> Michael C. Barros
     </footer>
@@ -100,17 +70,18 @@
     window.addEventListener('DOMContentLoaded', () => {
       const LINKS = (window.SITE_DATA && window.SITE_DATA.links) || window.LINKS || {};
       const EMAIL = (window.SITE_DATA && window.SITE_DATA.contact && window.SITE_DATA.contact.email) || 'barrostheology@gmail.com';
+      const PLACEHOLDER = 'hello@example.com';
 
       const blog = document.getElementById('nav-blog');
       if (blog) blog.href = LINKS.blog || 'https://mythonoesis.substack.com/';
       const research = document.getElementById('nav-research');
       if (research) research.href = LINKS.research || 'https://www.researchgate.net/';
 
-      const addrEl = document.getElementById('addr');
-      if (addrEl) addrEl.textContent = EMAIL;
-
       const mailto = document.getElementById('mailto');
       if (mailto) mailto.href = `mailto:${EMAIL}`;
+
+      const addr = document.getElementById('addr');
+      if (addr) addr.textContent = PLACEHOLDER;
 
       const copy = document.getElementById('copy');
       if (copy) {

--- a/index.html
+++ b/index.html
@@ -56,6 +56,12 @@
         </div>
       </section>
 
+      <section class="section-card">
+        <span class="eyebrow">Current research focus</span>
+        <h2>Formation of Supernatural Agents in Dreams Through Simulation</h2>
+        <p class="muted">My dissertation applies grounded cognition to dream data to explain how concepts of supernatural agents form and persist. I analyze ~1,200 dream reports from adults over 10–14 days (n=120), with a subsample wearing DREEM headbands (n=60). Dream content is coded for sensorimotor “simulation richness,” agent presence, and narrative structure, then tested against religiosity and paranormal belief scales, with REM sleep dynamics included. The goal is a mechanistic account of how dream simulations help construct and reactivate agent concepts.</p>
+      </section>
+
       <div class="divider" role="presentation"></div>
 
       <section aria-labelledby="book-heading">
@@ -93,38 +99,41 @@
           Editorial projects, institutes, and studies exploring how sacred imagination takes form across contemporary media.
         </p>
         <div class="grid cols-3" id="projects-grid">
-          <a class="card" href="./projects.html">
+          <a class="card card--waypoint" href="./projects.html#waypoint">
             <span class="card__motif" aria-hidden="true">
               <svg viewBox="0 0 120 120">
-                <circle cx="60" cy="60" r="36" />
-                <path d="M60 18v84M18 60h84" />
+                <circle cx="60" cy="60" r="40" />
+                <path d="M60 26v68M26 60h68" />
+                <path d="M60 18l12 24-12 10-12-10z" />
               </svg>
             </span>
             <span class="badge">Institute</span>
             <h3>Waypoint Institute</h3>
-            <p class="muted">Independent research and publishing initiative examining religion, imagination, and culture.</p>
+            <p class="muted">Independent research and publishing initiative mapping sacred imagination in culture.</p>
           </a>
-          <a class="card" href="./books.html">
+          <a class="card card--zelda-religion" href="./projects.html#zelda-religion">
             <span class="card__motif" aria-hidden="true">
               <svg viewBox="0 0 120 120">
-                <path d="M60 24l30 52H30z" />
-                <path d="M60 24v52" />
+                <path d="M60 26l22 38H38z" />
+                <path d="M60 26l-11 19h22z" />
+                <path d="M60 64l11 19H49z" />
               </svg>
             </span>
             <span class="badge">In Progress</span>
-            <h3>Zelda &amp; Religion</h3>
-            <p class="muted">Time, sacrifice, and mythopoesis in The Legend of Zelda through liturgical and theological frameworks.</p>
+            <h3>The Legend of Zelda &amp; Religion</h3>
+            <p class="muted">Time, sacrifice, and mythopoesis in Hyrule through liturgical and theological frameworks.</p>
           </a>
-          <a class="card" href="./books.html">
+          <a class="card card--dream-simulation" href="./projects.html#dream-simulation">
             <span class="card__motif" aria-hidden="true">
               <svg viewBox="0 0 120 120">
-                <rect x="28" y="28" width="64" height="64" rx="4" />
-                <path d="M28 60h64M60 28v64" />
+                <circle cx="60" cy="60" r="34" />
+                <path d="M36 60c0-13.3 10.7-24 24-24s24 10.7 24 24-10.7 24-24 24" />
+                <path d="M48 78c-9 0-16-7-16-16" />
               </svg>
             </span>
-            <span class="badge">Forthcoming</span>
-            <h3>The Esoteric Theology of Philip K. Dick</h3>
-            <p class="muted">Edited Bloomsbury volume interpreting Philip K. Dick’s theological imagination across literature and media.</p>
+            <span class="badge">Dissertation</span>
+            <h3>Formation of Supernatural Agents in Dreams</h3>
+            <p class="muted">ABD dissertation testing how dream simulation richness predicts religiosity and paranormal belief.</p>
           </a>
         </div>
       </section>
@@ -153,11 +162,11 @@
             <div class="feature-body">
               <span class="eyebrow">About Michael</span>
               <h3 id="bio-heading">Interdisciplinary scholar of religion, imagination, and media</h3>
-              <p class="muted">Based in Southern California, Michael C. Barros examines how sacred imagination is structured within games, film, and speculative fiction, drawing on theology, grounded cognition, and cultural history.</p>
+              <p class="muted">Michael C. Barros examines how sacred imagination is structured within games, film, and speculative fiction, drawing on theology, grounded cognition, and cultural history.</p>
               <p class="muted">He teaches across humanities and social science curricula and publishes on topics including Philip K. Dick, The Legend of Zelda, and religious experience in interactive worlds.</p>
               <div class="cta-row">
                 <a class="btn ghost" href="./about.html">Research overview</a>
-                <a class="btn" href="./contact.html">Contact &amp; speaking</a>
+                <a class="btn" href="./contact.html">Contact</a>
               </div>
             </div>
           </div>
@@ -168,11 +177,9 @@
     <footer>
       <p class="footer-tagline">Religion · Media · Imagination</p>
       <nav class="footer-links" aria-label="Secondary">
-        <a href="./assets/docs/michael-c-barros-cv.pdf" target="_blank" rel="noopener">CV (PDF)</a>
         <a href="https://mythonoesis.substack.com/" target="_blank" rel="noopener">Substack</a>
-        <a href="https://github.com/michaelcbarros" target="_blank" rel="noopener">GitHub</a>
-        <a href="https://orcid.org/" target="_blank" rel="noopener">ORCID</a>
-        <a href="https://independent.academia.edu/MichaelBarros" target="_blank" rel="noopener">Academia.edu</a>
+        <a href="https://orcid.org/0000-0001-5462-8926" target="_blank" rel="noopener">ORCID</a>
+        <a href="https://national.academia.edu/MichaelBarros" target="_blank" rel="noopener">Academia.edu</a>
       </nav>
       © <span id="year"></span> Michael C. Barros
     </footer>
@@ -195,12 +202,11 @@
         const motif = (id) => {
           switch (id) {
             case 'waypoint':
-              return '<span class="card__motif" aria-hidden="true"><svg viewBox="0 0 120 120"><circle cx="60" cy="60" r="40" /><path d="M60 24v72M24 60h72" /></svg></span>';
+              return '<span class="card__motif" aria-hidden="true"><svg viewBox="0 0 120 120"><circle cx="60" cy="60" r="40" /><path d="M60 26v68M26 60h68" /><path d="M60 18l12 24-12 10-12-10z" /></svg></span>';
             case 'zelda-religion':
-              return '<span class="card__motif" aria-hidden="true"><svg viewBox="0 0 120 120"><path d="M60 24l28 48H32z" /><path d="M60 24v48" /></svg></span>';
-            case 'pkd-theology-proj':
-            case 'pkd-theology':
-              return '<span class="card__motif" aria-hidden="true"><svg viewBox="0 0 120 120"><rect x="28" y="28" width="64" height="64" rx="6" /><path d="M28 60h64M60 28v64" /></svg></span>';
+              return '<span class="card__motif" aria-hidden="true"><svg viewBox="0 0 120 120"><path d="M60 26l22 38H38z" /><path d="M60 26l-11 19h22z" /><path d="M60 64l11 19H49z" /></svg></span>';
+            case 'dream-simulation':
+              return '<span class="card__motif" aria-hidden="true"><svg viewBox="0 0 120 120"><circle cx="60" cy="60" r="34" /><path d="M36 60c0-13.3 10.7-24 24-24s24 10.7 24 24-10.7 24-24 24" /><path d="M48 78c-9 0-16-7-16-16" /></svg></span>';
             default:
               return '<span class="card__motif" aria-hidden="true"><svg viewBox="0 0 120 120"><circle cx="60" cy="60" r="48" /><path d="M28 60h64M60 28v64" /></svg></span>';
           }
@@ -208,7 +214,8 @@
         grid.innerHTML = '';
         projects.slice(0, 6).forEach(p => {
           const link = document.createElement('a');
-          link.className = 'card';
+          const id = (p.id && String(p.id)) || slug(p.title);
+          link.className = `card card--${id}`;
           link.href = p.url || '#';
           if (p.external) {
             link.target = '_blank';
@@ -217,7 +224,7 @@
           const summary = p.short || p.summary || '';
           const detail = p.description || '';
           link.innerHTML = `
-            ${motif(p.id || p.title)}
+            ${motif(id)}
             <span class="badge">${p.status || p.type || 'Research'}</span>
             <h3>${p.title}</h3>
             ${summary ? `<p class="muted">${summary}</p>` : ''}
@@ -226,6 +233,15 @@
           grid.appendChild(link);
         });
       })();
+
+      function slug(value) {
+        return String(value || '')
+          .toLowerCase()
+          .trim()
+          .replace(/[^a-z0-9\s-]/g, '')
+          .replace(/\s+/g, '-')
+          .replace(/-+/g, '-');
+      }
 
       // substack
       (function(){

--- a/js/data/data.js
+++ b/js/data/data.js
@@ -54,34 +54,36 @@
       title: "Waypoint Institute",
       status: "Institute",
       type: "Collaboration",
-      tags: ["Religion", "Media"],
-      short: "Independent research and publishing initiative examining religion, imagination, and culture.",
-      description: "Curates symposia, publications, and public scholarship that surface sacred cartographies in contemporary media ecosystems.",
+      tags: ["Research", "Publishing", "Culture"],
+      short: "Independent institute curating studies of religion, imagination, and culture.",
+      description:
+        "Co-develops symposia, salons, and publications that chart sacred cartographies across media and civic life.",
       url: "./projects.html#waypoint",
       external: false
     },
     {
-      id: "pkd-theology-proj",
-      title: "Theology of Philip K. Dick",
-      status: "Forthcoming",
-      type: "Book",
-      tags: ["PKD", "Editing"],
-      short: "Edited scholarly volume (Bloomsbury, 2025) analysing Philip K. Dick's theological imagination.",
-      description:
-        "Essays trace Dick's visionary experiences, scriptural experimentation, and cultural afterlives across literature and screen adaptations.",
-      url: "./books.html#pkd-theology",
-      external: false
-    },
-    {
       id: "zelda-religion",
-      title: "Zelda & Religion",
+      title: "The Legend of Zelda & Religion",
       status: "In Progress",
-      type: "Book",
-      tags: ["Games", "Myth"],
+      type: "Book Project",
+      tags: ["Games", "Myth", "Theology"],
       short: "Time, sacrifice, and mythopoesis in The Legend of Zelda as a theological study of sacred structure within game worlds.",
       description:
         "Draws on ritual theory, liturgical studies, and ludology to articulate how Nintendo's series stages sacrificial imagination and heroic vocation.",
-      url: "./books.html#zelda-religion",
+      url: "./projects.html#zelda-religion",
+      external: false
+    },
+    {
+      id: "dream-simulation",
+      title: "Formation of Supernatural Agents in Dreams Through Simulation",
+      status: "Dissertation",
+      type: "Research Study",
+      tags: ["Dreams", "Grounded Cognition", "Religion"],
+      short:
+        "Formation of Supernatural Agents in Dreams Through Simulation — An ABD dissertation at National University testing whether the sensorimotor “simulation richness” of dream reports predicts religiosity and paranormal belief, using grounded cognition and a 10–14-day dataset (n=120; n=60 with REM measures).",
+      description:
+        "Analyzes ~1,200 longitudinal dream reports with REM metrics to model how simulation processes construct and reactivate supernatural agent concepts.",
+      url: "./projects.html#dream-simulation",
       external: false
     }
   ];

--- a/js/projects.js
+++ b/js/projects.js
@@ -98,7 +98,8 @@
 
     filtered.forEach((p) => {
       const card = document.createElement('a');
-      card.className = 'card';
+      const id = p.id || slugify(p.title);
+      card.className = `card card--${id}`;
       card.href = p.url || '#';
       if (p.external) {
         card.target = '_blank';
@@ -108,7 +109,7 @@
         ? `<div class="meta-row">${p.tags.map((tag) => `<span>${tag}</span>`).join('')}</div>`
         : '';
       card.innerHTML = `
-        ${motifMarkup(p.id)}
+        ${motifMarkup(id)}
         <span class="badge">${p.status || 'Research'}</span>
         <h3>${p.title}</h3>
         ${p.date ? `<p class="muted small">${formatDate(p.date)}</p>` : ''}
@@ -124,12 +125,11 @@
     const svg = (function () {
       switch (id) {
         case 'waypoint':
-          return '<svg viewBox="0 0 120 120"><circle cx="60" cy="60" r="40" /><path d="M60 24v72M24 60h72" /></svg>';
+          return '<svg viewBox="0 0 120 120"><circle cx="60" cy="60" r="40" /><path d="M60 26v68M26 60h68" /><path d="M60 18l12 24-12 10-12-10z" /></svg>';
         case 'zelda-religion':
-          return '<svg viewBox="0 0 120 120"><path d="M60 24l28 48H32z" /><path d="M60 24v48" /></svg>';
-        case 'pkd-theology-proj':
-        case 'pkd-theology':
-          return '<svg viewBox="0 0 120 120"><rect x="28" y="28" width="64" height="64" rx="6" /><path d="M28 60h64M60 28v64" /></svg>';
+          return '<svg viewBox="0 0 120 120"><path d="M60 26l22 38H38z" /><path d="M60 26l-11 19h22z" /><path d="M60 64l11 19H49z" /></svg>';
+        case 'dream-simulation':
+          return '<svg viewBox="0 0 120 120"><circle cx="60" cy="60" r="34" /><path d="M36 60c0-13.3 10.7-24 24-24s24 10.7 24 24-10.7 24-24 24" /><path d="M48 78c-9 0-16-7-16-16" /></svg>';
         default:
           return '<svg viewBox="0 0 120 120"><circle cx="60" cy="60" r="48" /><path d="M28 60h64M60 28v64" /></svg>';
       }

--- a/projects.html
+++ b/projects.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Projects — Michael C. Barros</title>
-  <meta name="description" content="Current research, collaborations, and media experiments exploring myth and the sacred." />
+  <meta name="description" content="Waypoint Institute, The Legend of Zelda &amp; Religion, and an ABD dissertation on dream-based supernatural agents." />
   <link rel="stylesheet" href="./style.css" />
   <style>
     .filters-panel {
@@ -16,6 +16,133 @@
     .filters-panel input[type="search"] {
       flex: 1 1 260px;
       min-width: 220px;
+    }
+    .project-detail {
+      margin-top: 2.8rem;
+      display: grid;
+      gap: 2rem;
+    }
+    @media (min-width: 980px) {
+      .project-detail {
+        grid-template-columns: minmax(0, 1.25fr) minmax(0, 1fr);
+        align-items: center;
+      }
+      .project-detail.project-detail--flip {
+        grid-template-columns: minmax(0, 1fr) minmax(0, 1.1fr);
+      }
+    }
+    .project-detail__content .badge {
+      margin-bottom: 0.8rem;
+    }
+    .project-detail__content h2 {
+      margin-bottom: 0.6rem;
+    }
+    .project-detail__content p {
+      margin-bottom: 1rem;
+    }
+    .project-detail__facts {
+      margin: 1.2rem 0 1.6rem;
+      display: grid;
+      gap: 0.65rem;
+    }
+    .project-detail__facts dt {
+      font-size: 0.78rem;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      color: var(--subtle);
+    }
+    .project-detail__facts dd {
+      margin: 0;
+      color: var(--muted);
+      font-weight: 500;
+    }
+    .project-detail__meta {
+      display: grid;
+      gap: 1.6rem;
+      margin-top: 1.6rem;
+    }
+    @media (min-width: 720px) {
+      .project-detail__meta {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+    }
+    .project-detail__meta-group h3 {
+      font-size: 1rem;
+      margin-bottom: 0.6rem;
+    }
+    .project-detail__list {
+      margin: 0;
+      padding-left: 1.2rem;
+      display: grid;
+      gap: 0.4rem;
+      color: var(--muted);
+    }
+    .project-graphic {
+      border-radius: var(--radius-lg);
+      border: 1px solid var(--border);
+      padding: 2rem;
+      background: var(--surface-soft);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      position: relative;
+      overflow: hidden;
+      min-height: 220px;
+    }
+    .project-graphic svg {
+      width: 100%;
+      max-width: 320px;
+      height: auto;
+      display: block;
+    }
+    .project-graphic--waypoint {
+      background: radial-gradient(circle at 30% 20%, rgba(28, 78, 110, 0.55), rgba(8, 20, 36, 0.95));
+      border-color: rgba(96, 174, 220, 0.45);
+    }
+    .project-graphic--waypoint svg {
+      stroke: rgba(132, 210, 255, 0.75);
+      fill: none;
+      stroke-width: 2;
+    }
+    .project-graphic--zelda {
+      background: radial-gradient(circle at 50% 0%, rgba(34, 74, 32, 0.8), rgba(14, 34, 22, 0.94));
+      border-color: rgba(162, 210, 92, 0.45);
+    }
+    .project-graphic--zelda svg path {
+      fill: rgba(228, 206, 128, 0.8);
+      stroke: rgba(255, 237, 164, 0.4);
+      stroke-width: 1.4;
+    }
+    .project-graphic--dream {
+      background: linear-gradient(135deg, rgba(52, 34, 96, 0.88), rgba(18, 46, 92, 0.92));
+      border-color: rgba(166, 146, 238, 0.45);
+    }
+    .project-graphic--dream svg {
+      stroke: rgba(214, 200, 255, 0.65);
+      fill: none;
+      stroke-width: 1.6;
+    }
+    .project-detail__caption {
+      margin-top: 0.9rem;
+      color: var(--subtle);
+      font-size: 0.85rem;
+    }
+    .project-detail__keywords {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+      margin: 0;
+      padding: 0;
+      list-style: none;
+    }
+    .project-detail__keywords li {
+      background: rgba(124, 108, 204, 0.18);
+      border: 1px solid rgba(166, 146, 238, 0.4);
+      border-radius: var(--radius-sm);
+      padding: 0.25rem 0.55rem;
+      color: var(--muted);
+      font-size: 0.82rem;
+      letter-spacing: 0.02em;
     }
   </style>
 </head>
@@ -52,16 +179,169 @@
         <div id="projects-grid" class="grid cols-3" style="margin-top: 2rem;"></div>
         <div id="empty" class="empty" style="display: none; margin-top: 1.5rem;">No projects match your filters yet—adjust the search or status.</div>
       </section>
+
+      <article class="section-card project-detail" id="waypoint">
+        <div class="project-detail__content">
+          <span class="badge">Institute</span>
+          <h2>Waypoint Institute</h2>
+          <p>Waypoint Institute is a collaborative research studio and publishing lab dedicated to mapping sacred imagination across culture. Borrowing the compass-driven palette of <a href="https://waypoint.institute" target="_blank" rel="noopener">waypoint.institute</a>, the project convenes scholars, artists, and community leaders to navigate questions of religion, civic storytelling, and public imagination.</p>
+          <p class="muted">Programming blends salons, residencies, and field reports that anchor spiritual inquiry in contemporary media and civic life.</p>
+          <div class="project-detail__meta">
+            <div class="project-detail__meta-group">
+              <h3>Initiatives</h3>
+              <ul class="project-detail__list">
+                <li>Compass salons on religion, imagination, and civic futures.</li>
+                <li>Limited-run publications and audio briefings on emergent sacred cartographies.</li>
+                <li>Advisory partnerships with cultural institutions and research collaborators.</li>
+              </ul>
+            </div>
+            <div class="project-detail__meta-group">
+              <h3>Focus areas</h3>
+              <ul class="project-detail__list">
+                <li>Religion &amp; civic storytelling</li>
+                <li>Grounded cognition &amp; imagination</li>
+                <li>Media ecologies &amp; spiritual formation</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+        <div class="project-detail__media" aria-hidden="true">
+          <div class="project-graphic project-graphic--waypoint">
+            <svg viewBox="0 0 240 240">
+              <circle cx="120" cy="120" r="82" />
+              <circle cx="120" cy="120" r="48" />
+              <path d="M120 40v160M40 120h160" />
+              <path d="M120 60l30 60-30 22-30-22z" />
+            </svg>
+          </div>
+          <p class="project-detail__caption">Compass motif and gradients echo the Waypoint Institute visual identity.</p>
+        </div>
+      </article>
+
+      <article class="section-card project-detail project-detail--flip" id="zelda-religion">
+        <div class="project-detail__media" aria-hidden="true">
+          <div class="project-graphic project-graphic--zelda">
+            <svg viewBox="0 0 260 260">
+              <circle cx="130" cy="130" r="102" stroke="rgba(228,206,128,0.4)" fill="none" stroke-width="6" />
+              <path d="M130 62l66 116H64z" />
+              <path d="M130 62l-34 58h68z" />
+              <path d="M130 156l34 58h-68z" />
+            </svg>
+          </div>
+          <p class="project-detail__caption">Triforce-inspired glyph for theological readings of Hyrule.</p>
+        </div>
+        <div class="project-detail__content">
+          <span class="badge">In Progress</span>
+          <h2>The Legend of Zelda &amp; Religion</h2>
+          <p>This book project examines The Legend of Zelda as a site of ritual, sacrifice, and mythopoesis. It traces how Nintendo’s series stages sacred time, liturgical repetition, and heroic vocation through interactive storytelling.</p>
+          <p class="muted">Research draws on liturgical studies, ritual theory, and game design analysis to link Hyrule’s geography with embodied religious imagination.</p>
+          <div class="project-detail__meta">
+            <div class="project-detail__meta-group">
+              <h3>Research threads</h3>
+              <ul class="project-detail__list">
+                <li>Temporal loops as liturgical calendars in franchise timelines.</li>
+                <li>Sacred geography, pilgrimage, and shrine networks across Hyrule.</li>
+                <li>Embodied play as ritual rehearsal of vocation and sacrifice.</li>
+              </ul>
+            </div>
+            <div class="project-detail__meta-group">
+              <h3>Outputs</h3>
+              <ul class="project-detail__list">
+                <li>Book proposal and chapter drafts (2025).</li>
+                <li>Conference papers on Zelda’s ritual architectures.</li>
+                <li>Public essays connecting game worlds to theological discourse.</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </article>
+
+      <article class="section-card project-detail" id="dream-simulation">
+        <div class="project-detail__content">
+          <span class="badge">Dissertation</span>
+          <h2>Formation of Supernatural Agents in Dreams Through Simulation</h2>
+          <dl class="project-detail__facts">
+            <div>
+              <dt>Status</dt>
+              <dd>Doctoral dissertation, National University (ABD, proposal stage, 2025)</dd>
+            </div>
+            <div>
+              <dt>Chair</dt>
+              <dd>Dr. Patrick McNamara</dd>
+            </div>
+          </dl>
+          <p>This study advances a grounded cognition account of how concepts of supernatural agents are constructed in dreams and later reengaged in waking life. It contrasts modular “agency detection” explanations with an embodied, simulation-based mechanism that foregrounds affect and situated valuation.</p>
+          <p>Using secondary analysis of a longitudinal dataset (n=120 adults; ~10–14 days; ~1,200 dream reports; n=60 with DREEM REM data), dream texts are coded for sensorimotor simulation richness, agentic figures, and narrative structure. Multiple regression models test whether simulation richness predicts scores on religiosity (BMMRS) and paranormal belief (RPBS), and whether REM sleep dynamics moderate these relationships.</p>
+          <div class="project-detail__meta">
+            <div class="project-detail__meta-group">
+              <h3>Research questions</h3>
+              <ul class="project-detail__list">
+                <li>RQ1: Does the richness of sensorimotor simulation in dream reports predict paranormal belief?</li>
+                <li>RQ2: Does simulated supernatural or agent content in dreams predict religiosity?</li>
+                <li>RQ3: How do REM sleep dynamics relate to, or moderate, these associations?</li>
+              </ul>
+            </div>
+            <div class="project-detail__meta-group">
+              <h3>Hypotheses</h3>
+              <ul class="project-detail__list">
+                <li>H1: Higher simulation richness in dreams positively predicts RPBS scores.</li>
+                <li>H2: Simulated supernatural or agent content positively predicts religiosity (BMMRS).</li>
+                <li>H3: REM-rich sleep is associated with greater simulation richness and strengthens the above relationships.</li>
+              </ul>
+            </div>
+            <div class="project-detail__meta-group">
+              <h3>Design &amp; measures</h3>
+              <ul class="project-detail__list">
+                <li>Secondary analysis of a 10–14-day longitudinal study (n=120 adults; ~1,200 dreams).</li>
+                <li>DREEM subsample (n=60) contributes REM percentage and sleep metrics.</li>
+                <li>Dream coding for sensorimotor detail, agent presence, and narrative structure.</li>
+                <li>Outcomes include religiosity (BMMRS) and paranormal belief (RPBS); regression models with relevant covariates.</li>
+              </ul>
+            </div>
+            <div class="project-detail__meta-group">
+              <h3>Contribution</h3>
+              <ul class="project-detail__list">
+                <li>Provides a mechanistic, embodied account of agent concept formation in dreams.</li>
+                <li>Bridges decentering processes in REM sleep with grounded cognition theory.</li>
+                <li>Clarifies the limits of hypersensitive agency detection models by specifying simulation processes tied to valuation and behavior.</li>
+              </ul>
+            </div>
+            <div class="project-detail__meta-group">
+              <h3>Keywords</h3>
+              <ul class="project-detail__keywords">
+                <li>Grounded Cognition</li>
+                <li>Perceptual Symbol Systems</li>
+                <li>Dreams</li>
+                <li>REM Sleep</li>
+                <li>Supernatural Agents</li>
+                <li>Simulation Richness</li>
+                <li>Religiosity</li>
+                <li>Paranormal Belief</li>
+                <li>Cognitive Science of Religion</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+        <div class="project-detail__media" aria-hidden="true">
+          <div class="project-graphic project-graphic--dream">
+            <svg viewBox="0 0 260 260">
+              <circle cx="130" cy="130" r="94" />
+              <path d="M86 180c-28-18-28-58 0-76s72-18 100 0 28 58 0 76" />
+              <path d="M110 202c-22 0-40-18-40-40" />
+              <path d="M150 74c24 4 42 24 42 48" />
+            </svg>
+          </div>
+          <p class="project-detail__caption">Dataset: ~1,200 dreams over 10–14 days with REM measures for a 60-participant subsample.</p>
+        </div>
+      </article>
     </main>
 
     <footer>
       <p class="footer-tagline">Religion · Media · Imagination</p>
       <nav class="footer-links" aria-label="Secondary">
-        <a href="./assets/docs/michael-c-barros-cv.pdf" target="_blank" rel="noopener">CV (PDF)</a>
         <a href="https://mythonoesis.substack.com/" target="_blank" rel="noopener">Substack</a>
-        <a href="https://github.com/michaelcbarros" target="_blank" rel="noopener">GitHub</a>
-        <a href="https://orcid.org/" target="_blank" rel="noopener">ORCID</a>
-        <a href="https://independent.academia.edu/MichaelBarros" target="_blank" rel="noopener">Academia.edu</a>
+        <a href="https://orcid.org/0000-0001-5462-8926" target="_blank" rel="noopener">ORCID</a>
+        <a href="https://national.academia.edu/MichaelBarros" target="_blank" rel="noopener">Academia.edu</a>
       </nav>
       © <span id="year"></span> Michael C. Barros
     </footer>

--- a/style.css
+++ b/style.css
@@ -418,6 +418,28 @@ a.nav__link::after {
   stroke-linecap: square;
   stroke-linejoin: miter;
 }
+.card--waypoint {
+  background: linear-gradient(135deg, rgba(11, 36, 62, 0.92), rgba(6, 18, 34, 0.92));
+  border-color: rgba(88, 163, 209, 0.45);
+}
+.card--waypoint .card__motif svg {
+  stroke: rgba(116, 204, 255, 0.6);
+}
+.card--zelda-religion {
+  background: radial-gradient(circle at 30% 30%, rgba(28, 60, 24, 0.85), rgba(12, 26, 18, 0.92));
+  border-color: rgba(140, 198, 63, 0.4);
+}
+.card--zelda-religion .card__motif svg {
+  stroke: rgba(218, 200, 120, 0.75);
+  fill: rgba(218, 200, 120, 0.18);
+}
+.card--dream-simulation {
+  background: linear-gradient(160deg, rgba(38, 28, 68, 0.92), rgba(18, 32, 60, 0.9));
+  border-color: rgba(147, 129, 226, 0.45);
+}
+.card--dream-simulation .card__motif svg {
+  stroke: rgba(204, 186, 255, 0.7);
+}
 
 .card:hover,
 .flip:hover .flip-face,


### PR DESCRIPTION
## Summary
- simplify the contact page copy to focus on general inquiries and remove the speaking/media section
- move the profile links to the about page, add a current research focus section, and refresh the homepage cards and CTA text accordingly
- replace the project data with Waypoint Institute, The Legend of Zelda & Religion, and the dissertation, adding detailed sections, theming, and new card motifs

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e30973b5d48330968481d0f8f59a18