### PR TITLE
Adjust bio training focus and approaches list

### DIFF
--- a/about.html
+++ b/about.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>About — Michael C. Barros</title>
   <meta name="description" content="Research overview for Michael C. Barros, scholar of religion and popular culture focusing on sacred imagination in media." />
-  <link rel="stylesheet" href="./style.css" />
+  <link rel="stylesheet" href="./style.css?v=20240607" />
   <style>
     .about-layout {
       display: grid;
@@ -99,6 +99,16 @@
     .page--about .info-card {
       padding: 1.6rem;
     }
+    .link-list {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+      display: grid;
+      gap: 0.6rem;
+    }
+    .link-list a {
+      color: var(--accent);
+    }
   </style>
 </head>
 <body class="page page--about">
@@ -119,11 +129,11 @@
       <section class="page-header">
         <span class="eyebrow">About</span>
         <h1 class="page-title">About Michael C. Barros</h1>
-        <p class="page-kicker">Interdisciplinary scholar of religion and media investigating how sacred imagination is structured within contemporary storytelling.</p>
+        <p class="page-kicker">Scholar of religion &amp; culture.</p>
         <div class="cta-row" role="group" aria-label="Primary actions">
           <a class="btn" href="./books.html">Books</a>
           <a class="btn" href="./projects.html">Projects</a>
-          <a class="btn" href="./contact.html#cv">Curriculum Vitae</a>
+          <a class="btn" href="#profiles">Profiles</a>
         </div>
       </section>
 
@@ -131,9 +141,9 @@
         <div class="about-layout">
           <div>
             <h2>Research Overview</h2>
-            <p>Michael C. Barros is an interdisciplinary scholar whose work explores how myth, ritual, and sacred imagination emerge within contemporary media. He is currently ABD in Psychology at National University, where his dissertation examines the cognitive formation of supernatural agents in dreams through grounded cognition theory.</p>
-            <p>He holds a Master’s degree in Biblical and Theological Studies and has taught humanities, philosophy, and psychology at both secondary and postsecondary levels. His research integrates theology, cognitive science, and cultural analysis, with publications on religion in video games, Philip K. Dick, archetypal criticism, and media theory.</p>
-            <p>He serves as co-editor of <em>The Esoteric Theology of Philip K. Dick</em> (Bloomsbury, forthcoming 2025) and has published in venues including <em>Academia Letters</em>, <em>The Classical Connection</em>, and <em>SSHJ</em>.</p>
+            <p>Michael C. Barros is an interdisciplinary scholar of religion and culture with training in psychology and theology, and a background in classical education. He teaches philosophy at the University of the People and has taught undergraduate theology, philosophy, and literature. He is ABD in psychology at National University.</p>
+            <p>His dissertation, <em>Formation of Supernatural Agents in Dreams Through Simulation: A Grounded Cognition Perspective</em>, develops a grounded-cognition account of how dream simulations help form and sustain concepts of supernatural agents.</p>
+            <p>His research draws on the cognitive science of religion, theology, and cultural analysis, with particular attention to dreams, ritual and imagination, and how games, film, and speculative fiction function as sites of religious meaning. He is co-editor of <em>The Esoteric Theology of Philip K. Dick</em>.</p>
           </div>
           <aside class="about-sidebar" aria-label="Quick facts">
             <h3>Quick facts</h3>
@@ -148,15 +158,21 @@
               </li>
               <li class="about-fact">
                 <span class="about-fact__label">Fields</span>
-                <span class="about-fact__value">Religion &amp; Media, Theology, Grounded Cognition, Cultural History</span>
+                <span class="about-fact__value">Media &amp; game studies; Cognitive science of religion; Religion &amp; culture</span>
               </li>
               <li class="about-fact">
                 <span class="about-fact__label">Publications</span>
-                <span class="about-fact__value">6+ peer-reviewed articles, 2 book chapters, 1 edited volume</span>
+                <span class="about-fact__value">7 articles · 1 book · 1 chapter</span>
               </li>
             </ul>
           </aside>
         </div>
+      </section>
+
+      <section class="section-card">
+        <span class="eyebrow">Current research focus</span>
+        <h2>Formation of Supernatural Agents in Dreams Through Simulation</h2>
+        <p>My dissertation applies grounded cognition to dream data to explain how concepts of supernatural agents form and persist. I analyze ~1,200 dream reports from adults over 10–14 days (n=120), with a subsample wearing DREEM headbands (n=60). Dream content is coded for sensorimotor “simulation richness,” agent presence, and narrative structure, then tested against religiosity and paranormal belief scales, with REM sleep dynamics included. The goal is a mechanistic account of how dream simulations help construct and reactivate agent concepts.</p>
       </section>
 
       <div class="divider" role="presentation"></div>
@@ -229,27 +245,7 @@
                     <path d="M5 10h14M9 6v12" />
                   </svg>
                 </span>
-                <span>Media analysis &amp; cultural history</span>
-              </li>
-              <li>
-                <span class="about-icon" aria-hidden="true">
-                  <svg viewBox="0 0 24 24">
-                    <circle cx="7" cy="12" r="2.2" />
-                    <circle cx="17" cy="8" r="2.2" />
-                    <circle cx="17" cy="16" r="2.2" />
-                    <path d="M9 11l6-2M9 13l6 2" />
-                  </svg>
-                </span>
-                <span>Reception &amp; adaptation studies</span>
-              </li>
-              <li>
-                <span class="about-icon" aria-hidden="true">
-                  <svg viewBox="0 0 24 24">
-                    <path d="M4 15c1.5-1.5 3.5-1.5 5 0s3.5 1.5 5 0 3.5-1.5 5 0" />
-                    <path d="M4 9c1.5 1.5 3.5 1.5 5 0s3.5-1.5 5 0 3.5 1.5 5 0" />
-                  </svg>
-                </span>
-                <span>Ethnography of fandom &amp; play</span>
+                <span>Media analysis</span>
               </li>
             </ul>
           </article>
@@ -263,10 +259,14 @@
           <h2>Connect</h2>
         </div>
         <div class="detail-grid two-col">
-          <article class="info-card">
-            <h3>Research profiles</h3>
-            <p>External publications, preprints, and works-in-progress.</p>
-            <a class="btn" id="about-research" href="#" target="_blank" rel="noopener">Open Research</a>
+          <article class="info-card" id="profiles">
+            <h3>Profiles</h3>
+            <ul class="link-list">
+              <li><a href="https://www.researchgate.net/profile/Michael-Barros-2" target="_blank" rel="noopener">ResearchGate</a></li>
+              <li><a href="https://mythonoesis.substack.com/" target="_blank" rel="noopener">Substack</a></li>
+              <li><a href="https://orcid.org/0000-0001-5462-8926" target="_blank" rel="noopener">ORCID</a></li>
+              <li><a href="https://national.academia.edu/MichaelBarros" target="_blank" rel="noopener">Academia.edu</a></li>
+            </ul>
           </article>
           <article class="info-card">
             <h3>Substack</h3>
@@ -280,23 +280,19 @@
     <footer>
       <p class="footer-tagline">Religion · Media · Imagination</p>
       <nav class="footer-links" aria-label="Secondary">
-        <a href="./assets/docs/michael-c-barros-cv.pdf" target="_blank" rel="noopener">CV (PDF)</a>
         <a href="https://mythonoesis.substack.com/" target="_blank" rel="noopener">Substack</a>
-        <a href="https://github.com/michaelcbarros" target="_blank" rel="noopener">GitHub</a>
-        <a href="https://orcid.org/" target="_blank" rel="noopener">ORCID</a>
-        <a href="https://independent.academia.edu/MichaelBarros" target="_blank" rel="noopener">Academia.edu</a>
+        <a href="https://orcid.org/0000-0001-5462-8926" target="_blank" rel="noopener">ORCID</a>
+        <a href="https://national.academia.edu/MichaelBarros" target="_blank" rel="noopener">Academia.edu</a>
       </nav>
       © <span id="year"></span> Michael C. Barros
     </footer>
   </div>
 
-  <script defer src="./js/data/data.js"></script>
-  <script defer src="./js/nav.js"></script>
+  <script defer src="./js/data/data.js?v=20240607"></script>
+  <script defer src="./js/nav.js?v=20240607"></script>
   <script>
     window.addEventListener('DOMContentLoaded', () => {
       const links = (window.SITE_DATA && window.SITE_DATA.links) || window.LINKS || {};
-      const research = document.getElementById('about-research');
-      if (research) research.href = links.research || 'https://www.researchgate.net/';
       const blog = document.getElementById('about-blog');
       if (blog) blog.href = links.blog || 'https://mythonoesis.substack.com/';
       const year = document.getElementById('year');

--- a/books.html
+++ b/books.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Books — Michael C. Barros</title>
   <meta name="description" content="Books and forthcoming work on religion, myth, and popular culture by Michael C. Barros." />
-  <link rel="stylesheet" href="./style.css" />
+  <link rel="stylesheet" href="./style.css?v=20240607" />
   <style>
     .book-hero {
       display: grid;
@@ -42,7 +42,7 @@
       color: var(--ink);
     }
   </style>
-  <script defer src="./js/data/data.js"></script>
+  <script defer src="./js/data/data.js?v=20240607"></script>
 </head>
 <body class="page page--books">
   <div class="shell">
@@ -78,10 +78,10 @@
               <p class="muted">Edited scholarly volume (Bloomsbury, 2025) examining Philip K. Dick’s theological imagination across literature and adaptation.</p>
               <div class="cta-row">
                 <a class="btn" href="https://amzn.to/46Fn12N" target="_blank" rel="noopener">Preorder</a>
-                <a class="btn ghost" href="./books.html#pkd-theology">Publication details</a>
               </div>
             </div>
           </div>
+          <button type="button" class="btn ghost" id="book-toggle" aria-expanded="false" aria-controls="book-extras" style="margin-top: 1.5rem; display: none;">Read more</button>
           <div id="book-extras" class="detail-grid" style="margin-top: 2rem; display: none;">
             <div class="book-copy" id="book-desc"></div>
             <div class="detail-grid" id="book-blurbs"></div>
@@ -100,11 +100,9 @@
     <footer>
       <p class="footer-tagline">Religion · Media · Imagination</p>
       <nav class="footer-links" aria-label="Secondary">
-        <a href="./assets/docs/michael-c-barros-cv.pdf" target="_blank" rel="noopener">CV (PDF)</a>
         <a href="https://mythonoesis.substack.com/" target="_blank" rel="noopener">Substack</a>
-        <a href="https://github.com/michaelcbarros" target="_blank" rel="noopener">GitHub</a>
-        <a href="https://orcid.org/" target="_blank" rel="noopener">ORCID</a>
-        <a href="https://independent.academia.edu/MichaelBarros" target="_blank" rel="noopener">Academia.edu</a>
+        <a href="https://orcid.org/0000-0001-5462-8926" target="_blank" rel="noopener">ORCID</a>
+        <a href="https://national.academia.edu/MichaelBarros" target="_blank" rel="noopener">Academia.edu</a>
       </nav>
       © <span id="year"></span> Michael C. Barros
     </footer>
@@ -143,12 +141,12 @@
           ${featured.summary ? `<p class="muted">${featured.summary}</p>` : ''}
           <div class="cta-row">
             ${buy ? `<a class="btn" href="${buy.url}" target="_blank" rel="noopener">${buy.label || 'Preorder'}</a>` : ''}
-            ${featured.url ? `<a class="btn ghost" href="${featured.url}">Publication details</a>` : ''}
           </div>
         </div>
       `;
 
       const extras = document.getElementById('book-extras');
+      const toggleBtn = document.getElementById('book-toggle');
       const descEl = document.getElementById('book-desc');
       const blurbsEl = document.getElementById('book-blurbs');
 
@@ -171,8 +169,25 @@
         `).join('');
       }
 
-      if ((paragraphs.length || reviews.length) && extras) {
-        extras.style.display = 'grid';
+      const hasExtras = (paragraphs.length || reviews.length) > 0;
+
+      if (hasExtras && toggleBtn && extras) {
+        const setExpanded = (expanded) => {
+          extras.style.display = expanded ? 'grid' : 'none';
+          toggleBtn.textContent = expanded ? 'Read less' : 'Read more';
+          toggleBtn.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+          extras.setAttribute('aria-hidden', expanded ? 'false' : 'true');
+        };
+
+        toggleBtn.style.display = 'inline-flex';
+        setExpanded(false);
+
+        toggleBtn.addEventListener('click', () => {
+          const isExpanded = toggleBtn.getAttribute('aria-expanded') === 'true';
+          setExpanded(!isExpanded);
+        });
+      } else if (toggleBtn) {
+        toggleBtn.style.display = 'none';
       }
 
       const others = books.filter(b => b !== featured);
@@ -198,6 +213,6 @@
       }
     });
   </script>
-  <script defer src="./js/nav.js"></script>
+  <script defer src="./js/nav.js?v=20240607"></script>
 </body>
 </html>

--- a/contact.html
+++ b/contact.html
@@ -4,8 +4,8 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Contact — Michael C. Barros</title>
-  <meta name="description" content="Get in touch with Michael C. Barros for speaking, media, or collaboration." />
-  <link rel="stylesheet" href="./style.css" />
+  <meta name="description" content="Get in touch with Michael C. Barros for collaborations, research inquiries, or general questions." />
+  <link rel="stylesheet" href="./style.css?v=20240607" />
   <style>
     .contact-grid {
       display: grid;
@@ -16,16 +16,6 @@
       gap: 0.75rem;
       flex-wrap: wrap;
       align-items: center;
-    }
-    .link-list {
-      list-style: none;
-      padding: 0;
-      margin: 0;
-      display: grid;
-      gap: 0.6rem;
-    }
-    .link-list a {
-      color: var(--accent);
     }
   </style>
 </head>
@@ -46,37 +36,19 @@
     <main>
       <section class="page-header">
         <span class="eyebrow">Contact</span>
-        <h1 class="page-title">Contact &amp; Speaking</h1>
-        <p class="page-kicker">For speaking invitations, interviews, or collaborations, please include event details, proposed dates, and format. I respond to all messages as time permits.</p>
+        <h1 class="page-title">Contact</h1>
+        <p class="page-kicker">Reach out regarding research collaborations, writing, teaching, or general questions. I reply as time allows.</p>
       </section>
 
       <section class="contact-grid">
         <article class="section-card">
           <h2>Email</h2>
-          <p class="muted">Include event context, proposed dates, and format in your initial message.</p>
+          <p class="muted">Share a brief introduction and how I can help; I typically respond within a few days.</p>
           <div class="contact-actions">
-            <code id="addr">barrostheology@gmail.com</code>
+            <code id="addr">hello@example.com</code>
             <button id="copy" class="btn ghost" type="button">Copy</button>
             <a id="mailto" class="btn" href="#">Compose email</a>
           </div>
-        </article>
-
-        <article class="section-card">
-          <h2>Speaking &amp; media</h2>
-          <p class="muted">Michael has delivered talks and lectures at conferences including SWPACA and The Middle Ages in Modern Games. He is available for keynotes, seminars, and interviews on religion and media, Philip K. Dick, grounded cognition, and cultural theory.</p>
-        </article>
-
-        <article class="section-card" id="cv">
-          <h2>Curriculum vitae &amp; profiles</h2>
-          <p class="muted">Download the current CV or connect via research platforms.</p>
-          <ul class="link-list">
-            <li><a href="./assets/docs/michael-c-barros-cv.pdf" target="_blank" rel="noopener">Curriculum Vitae (PDF)</a></li>
-            <li><a href="https://www.researchgate.net/profile/Michael-Barros-2" target="_blank" rel="noopener">ResearchGate</a></li>
-            <li><a href="https://mythonoesis.substack.com/" target="_blank" rel="noopener">Substack — Mythonoesis</a></li>
-            <li><a href="https://github.com/michaelcbarros" target="_blank" rel="noopener">GitHub</a></li>
-            <li><a href="https://orcid.org/" target="_blank" rel="noopener">ORCID (profile forthcoming)</a></li>
-            <li><a href="https://independent.academia.edu/MichaelBarros" target="_blank" rel="noopener">Academia.edu</a></li>
-          </ul>
         </article>
       </section>
     </main>
@@ -84,33 +56,32 @@
     <footer>
       <p class="footer-tagline">Religion · Media · Imagination</p>
       <nav class="footer-links" aria-label="Secondary">
-        <a href="./assets/docs/michael-c-barros-cv.pdf" target="_blank" rel="noopener">CV (PDF)</a>
         <a href="https://mythonoesis.substack.com/" target="_blank" rel="noopener">Substack</a>
-        <a href="https://github.com/michaelcbarros" target="_blank" rel="noopener">GitHub</a>
-        <a href="https://orcid.org/" target="_blank" rel="noopener">ORCID</a>
-        <a href="https://independent.academia.edu/MichaelBarros" target="_blank" rel="noopener">Academia.edu</a>
+        <a href="https://orcid.org/0000-0001-5462-8926" target="_blank" rel="noopener">ORCID</a>
+        <a href="https://national.academia.edu/MichaelBarros" target="_blank" rel="noopener">Academia.edu</a>
       </nav>
       © <span id="year"></span> Michael C. Barros
     </footer>
   </div>
 
-  <script defer src="./js/data/data.js"></script>
-  <script defer src="./js/nav.js"></script>
+  <script defer src="./js/data/data.js?v=20240607"></script>
+  <script defer src="./js/nav.js?v=20240607"></script>
   <script>
     window.addEventListener('DOMContentLoaded', () => {
       const LINKS = (window.SITE_DATA && window.SITE_DATA.links) || window.LINKS || {};
       const EMAIL = (window.SITE_DATA && window.SITE_DATA.contact && window.SITE_DATA.contact.email) || 'barrostheology@gmail.com';
+      const PLACEHOLDER = 'hello@example.com';
 
       const blog = document.getElementById('nav-blog');
       if (blog) blog.href = LINKS.blog || 'https://mythonoesis.substack.com/';
       const research = document.getElementById('nav-research');
       if (research) research.href = LINKS.research || 'https://www.researchgate.net/';
 
-      const addrEl = document.getElementById('addr');
-      if (addrEl) addrEl.textContent = EMAIL;
-
       const mailto = document.getElementById('mailto');
       if (mailto) mailto.href = `mailto:${EMAIL}`;
+
+      const addr = document.getElementById('addr');
+      if (addr) addr.textContent = PLACEHOLDER;
 
       const copy = document.getElementById('copy');
       if (copy) {

--- a/index.html
+++ b/index.html
@@ -3,11 +3,11 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Michael C. Barros — Scholarship at the Intersection of Religion and Contemporary Media</title>
-  <meta name="description" content="Interdisciplinary research on religion, imagination, and media by Michael C. Barros." />
+  <title>Michael C. Barros — Scholar of religion &amp; culture</title>
+  <meta name="description" content="Scholar of religion and culture exploring dreams, ritual, imagination, and media." />
   <meta name="theme-color" content="#050310" />
 
-  <link rel="stylesheet" href="./style.css" />
+  <link rel="stylesheet" href="./style.css?v=20240607" />
 </head>
 
 <body class="home">
@@ -27,31 +27,20 @@
     <main>
       <section class="hero" aria-labelledby="home-title">
         <div class="hero__content">
-          <h1 id="home-title">Scholarship at the Intersection of Religion and Contemporary Media</h1>
+          <h1 id="home-title">Scholar of religion &amp; culture</h1>
           <p class="hero__tagline">
-            Michael C. Barros studies how myth, ritual, and sacred imagination manifest in games, film, and speculative fiction. His research integrates theology, cognitive science, and cultural history to illuminate how sacred meaning is generated in modern contexts.
+            Michael C. Barros is an interdisciplinary scholar of religion and culture with training in psychology and theology, and a background in classical education. He teaches philosophy at the University of the People and has taught undergraduate theology, philosophy, and literature.
           </p>
           <div class="hero__meta">
             <div class="badge-row" aria-label="Areas of focus">
-              <span class="badge">Games</span>
-              <span class="badge">Film</span>
-              <span class="badge">Speculative Fiction</span>
+              <span class="badge">Media &amp; game studies</span>
+              <span class="badge">Cognitive science of religion</span>
+              <span class="badge">Religion &amp; culture</span>
             </div>
             <div class="cta-row" role="group" aria-label="Primary actions">
               <a class="btn" href="./projects.html">Explore Work</a>
               <a class="btn ghost" id="cta-blog" href="#" target="_blank" rel="noopener">Read Blog</a>
             </div>
-          </div>
-        </div>
-        <div class="hero__media" aria-hidden="true">
-          <div class="hero__motif">
-            <svg viewBox="0 0 200 200" role="presentation" aria-hidden="true">
-              <circle cx="100" cy="100" r="72" stroke="rgba(147,153,182,0.45)" stroke-width="1" fill="none" />
-              <circle cx="100" cy="100" r="38" stroke="rgba(147,153,182,0.35)" stroke-width="1" fill="none" />
-              <path d="M32 100h136M100 32v136" stroke="rgba(195,170,106,0.45)" stroke-width="1" />
-              <path d="M56 56l88 88M56 144l88-88" stroke="rgba(147,153,182,0.35)" stroke-width="1" />
-              <path d="M100 56l28 44-28 44-28-44z" stroke="rgba(195,170,106,0.45)" fill="none" />
-            </svg>
           </div>
         </div>
       </section>
@@ -93,38 +82,41 @@
           Editorial projects, institutes, and studies exploring how sacred imagination takes form across contemporary media.
         </p>
         <div class="grid cols-3" id="projects-grid">
-          <a class="card" href="./projects.html">
+          <a class="card card--waypoint" href="./projects.html#waypoint">
             <span class="card__motif" aria-hidden="true">
               <svg viewBox="0 0 120 120">
-                <circle cx="60" cy="60" r="36" />
-                <path d="M60 18v84M18 60h84" />
+                <circle cx="60" cy="60" r="40" />
+                <path d="M60 26v68M26 60h68" />
+                <path d="M60 18l12 24-12 10-12-10z" />
               </svg>
             </span>
             <span class="badge">Institute</span>
             <h3>Waypoint Institute</h3>
-            <p class="muted">Independent research and publishing initiative examining religion, imagination, and culture.</p>
+            <p class="muted">Tuition-free Christian education: great-books core, cohort-based, donor-supported.</p>
           </a>
-          <a class="card" href="./books.html">
+          <a class="card card--dissertation" href="./projects.html#dissertation">
             <span class="card__motif" aria-hidden="true">
               <svg viewBox="0 0 120 120">
-                <path d="M60 24l30 52H30z" />
-                <path d="M60 24v52" />
+                <circle cx="60" cy="60" r="34" />
+                <path d="M36 60c0-13.3 10.7-24 24-24s24 10.7 24 24-10.7 24-24 24" />
+                <path d="M48 78c-9 0-16-7-16-16" />
               </svg>
             </span>
-            <span class="badge">In Progress</span>
-            <h3>Zelda &amp; Religion</h3>
-            <p class="muted">Time, sacrifice, and mythopoesis in The Legend of Zelda through liturgical and theological frameworks.</p>
+            <span class="badge">Dissertation</span>
+            <h3>Formation of Supernatural Agents in Dreams Through Simulation: A Grounded Cognition Perspective</h3>
+            <p class="muted">Dream simulation and belief—an embodied, grounded-cognition account.</p>
           </a>
-          <a class="card" href="./books.html">
+          <a class="card card--zelda" href="./projects.html#zelda">
             <span class="card__motif" aria-hidden="true">
               <svg viewBox="0 0 120 120">
-                <rect x="28" y="28" width="64" height="64" rx="4" />
-                <path d="M28 60h64M60 28v64" />
+                <path d="M60 26l22 38H38z" />
+                <path d="M60 26l-11 19h22z" />
+                <path d="M60 64l11 19H49z" />
               </svg>
             </span>
-            <span class="badge">Forthcoming</span>
-            <h3>The Esoteric Theology of Philip K. Dick</h3>
-            <p class="muted">Edited Bloomsbury volume interpreting Philip K. Dick’s theological imagination across literature and media.</p>
+            <span class="badge">Edited Volume</span>
+            <h3>The Legend of Zelda and Religion</h3>
+            <p class="muted">Zelda as theology—religion emerging from inside the game world.</p>
           </a>
         </div>
       </section>
@@ -152,12 +144,12 @@
             <div class="feature-media feature-media--avatar" role="img" aria-label="Abstract portrait of Michael C. Barros"></div>
             <div class="feature-body">
               <span class="eyebrow">About Michael</span>
-              <h3 id="bio-heading">Interdisciplinary scholar of religion, imagination, and media</h3>
-              <p class="muted">Based in Southern California, Michael C. Barros examines how sacred imagination is structured within games, film, and speculative fiction, drawing on theology, grounded cognition, and cultural history.</p>
-              <p class="muted">He teaches across humanities and social science curricula and publishes on topics including Philip K. Dick, The Legend of Zelda, and religious experience in interactive worlds.</p>
+              <h3 id="bio-heading">Scholar of religion &amp; culture</h3>
+              <p class="muted">Michael C. Barros is an interdisciplinary scholar of religion and culture with training in psychology and theology, and a background in classical education.</p>
+              <p class="muted">He teaches philosophy at the University of the People, has taught undergraduate theology, philosophy, and literature, and researches dreams, ritual, imagination, and sacred meaning in media.</p>
               <div class="cta-row">
                 <a class="btn ghost" href="./about.html">Research overview</a>
-                <a class="btn" href="./contact.html">Contact &amp; speaking</a>
+                <a class="btn" href="./contact.html">Contact</a>
               </div>
             </div>
           </div>
@@ -168,18 +160,16 @@
     <footer>
       <p class="footer-tagline">Religion · Media · Imagination</p>
       <nav class="footer-links" aria-label="Secondary">
-        <a href="./assets/docs/michael-c-barros-cv.pdf" target="_blank" rel="noopener">CV (PDF)</a>
         <a href="https://mythonoesis.substack.com/" target="_blank" rel="noopener">Substack</a>
-        <a href="https://github.com/michaelcbarros" target="_blank" rel="noopener">GitHub</a>
-        <a href="https://orcid.org/" target="_blank" rel="noopener">ORCID</a>
-        <a href="https://independent.academia.edu/MichaelBarros" target="_blank" rel="noopener">Academia.edu</a>
+        <a href="https://orcid.org/0000-0001-5462-8926" target="_blank" rel="noopener">ORCID</a>
+        <a href="https://national.academia.edu/MichaelBarros" target="_blank" rel="noopener">Academia.edu</a>
       </nav>
       © <span id="year"></span> Michael C. Barros
     </footer>
   </div>
 
-  <script defer src="./js/data/data.js"></script>
-  <script defer src="./js/nav.js"></script>
+  <script defer src="./js/data/data.js?v=20240607"></script>
+  <script defer src="./js/nav.js?v=20240607"></script>
   <script>
     window.addEventListener('DOMContentLoaded', () => {
       // footer year
@@ -195,12 +185,11 @@
         const motif = (id) => {
           switch (id) {
             case 'waypoint':
-              return '<span class="card__motif" aria-hidden="true"><svg viewBox="0 0 120 120"><circle cx="60" cy="60" r="40" /><path d="M60 24v72M24 60h72" /></svg></span>';
-            case 'zelda-religion':
-              return '<span class="card__motif" aria-hidden="true"><svg viewBox="0 0 120 120"><path d="M60 24l28 48H32z" /><path d="M60 24v48" /></svg></span>';
-            case 'pkd-theology-proj':
-            case 'pkd-theology':
-              return '<span class="card__motif" aria-hidden="true"><svg viewBox="0 0 120 120"><rect x="28" y="28" width="64" height="64" rx="6" /><path d="M28 60h64M60 28v64" /></svg></span>';
+              return '<span class="card__motif" aria-hidden="true"><svg viewBox="0 0 120 120"><circle cx="60" cy="60" r="40" /><path d="M60 26v68M26 60h68" /><path d="M60 18l12 24-12 10-12-10z" /></svg></span>';
+            case 'dissertation':
+              return '<span class="card__motif" aria-hidden="true"><svg viewBox="0 0 120 120"><circle cx="60" cy="60" r="34" /><path d="M36 60c0-13.3 10.7-24 24-24s24 10.7 24 24-10.7 24-24 24" /><path d="M48 78c-9 0-16-7-16-16" /></svg></span>';
+            case 'zelda':
+              return '<span class="card__motif" aria-hidden="true"><svg viewBox="0 0 120 120"><path d="M60 26l22 38H38z" /><path d="M60 26l-11 19h22z" /><path d="M60 64l11 19H49z" /></svg></span>';
             default:
               return '<span class="card__motif" aria-hidden="true"><svg viewBox="0 0 120 120"><circle cx="60" cy="60" r="48" /><path d="M28 60h64M60 28v64" /></svg></span>';
           }
@@ -208,24 +197,32 @@
         grid.innerHTML = '';
         projects.slice(0, 6).forEach(p => {
           const link = document.createElement('a');
-          link.className = 'card';
+          const id = (p.id && String(p.id)) || slug(p.title);
+          link.className = `card card--${id}`;
           link.href = p.url || '#';
           if (p.external) {
             link.target = '_blank';
             link.rel = 'noopener';
           }
           const summary = p.short || p.summary || '';
-          const detail = p.description || '';
           link.innerHTML = `
-            ${motif(p.id || p.title)}
+            ${motif(id)}
             <span class="badge">${p.status || p.type || 'Research'}</span>
             <h3>${p.title}</h3>
             ${summary ? `<p class="muted">${summary}</p>` : ''}
-            ${detail ? `<p class="muted small">${detail}</p>` : ''}
           `;
           grid.appendChild(link);
         });
       })();
+
+      function slug(value) {
+        return String(value || '')
+          .toLowerCase()
+          .trim()
+          .replace(/[^a-z0-9\s-]/g, '')
+          .replace(/\s+/g, '-')
+          .replace(/-+/g, '-');
+      }
 
       // substack
       (function(){

--- a/js/data/data.js
+++ b/js/data/data.js
@@ -14,7 +14,7 @@
 
   // ---------- Taglines (homepage rotator) ----------
   const TAGLINES = [
-    "Interdisciplinary scholarship on religion, imagination, and media.",
+    "Scholar of religion & culture exploring dreams, ritual, and imagination in media.",
     "Analysing contemporary storytelling through theological and cultural history.",
     "Grounded cognition, sacred imagination, and popular culture."
   ];
@@ -54,34 +54,38 @@
       title: "Waypoint Institute",
       status: "Institute",
       type: "Collaboration",
-      tags: ["Religion", "Media"],
-      short: "Independent research and publishing initiative examining religion, imagination, and culture.",
-      description: "Curates symposia, publications, and public scholarship that surface sacred cartographies in contemporary media ecosystems.",
+      tags: ["Education", "Theology", "Great Books"],
+      short:
+        "Tuition-free Christian education: great-books core, cohort-based, donor-supported.",
+      description:
+        "Waypoint is a donor-supported, tuition-free Christian education project. We deliver a great-books core in Scripture, classical theology, and the liberal arts through online cohorts, clear syllabi, and a curated public-domain library. The emphasis is formation and rigorous study, with straightforward credit pathways for students who need them—so learners focus on reading, discussion, and service rather than cost or bureaucracy.",
       url: "./projects.html#waypoint",
       external: false
     },
     {
-      id: "pkd-theology-proj",
-      title: "Theology of Philip K. Dick",
-      status: "Forthcoming",
-      type: "Book",
-      tags: ["PKD", "Editing"],
-      short: "Edited scholarly volume (Bloomsbury, 2025) analysing Philip K. Dick's theological imagination.",
+      id: "dissertation",
+      title: "Formation of Supernatural Agents in Dreams Through Simulation: A Grounded Cognition Perspective",
+      status: "Dissertation",
+      type: "Research Study",
+      tags: ["Dreams", "Grounded Cognition", "Religion"],
+      short:
+        "Dream simulation and belief—an embodied, grounded-cognition account.",
       description:
-        "Essays trace Dick's visionary experiences, scriptural experimentation, and cultural afterlives across literature and screen adaptations.",
-      url: "./books.html#pkd-theology",
+        "My dissertation develops a grounded-cognition model of how dream simulations help people form and sustain concepts of supernatural agents. It operationalizes “simulation richness” (sensorimotor detail, agency, narrative) in dream reports and examines its relationship to religious and paranormal beliefs. The aim is a mechanistic, embodied alternative to simple “agency-detection” explanations in the cognitive science of religion.",
+      url: "./projects.html#dissertation",
       external: false
     },
     {
-      id: "zelda-religion",
-      title: "Zelda & Religion",
-      status: "In Progress",
-      type: "Book",
-      tags: ["Games", "Myth"],
-      short: "Time, sacrifice, and mythopoesis in The Legend of Zelda as a theological study of sacred structure within game worlds.",
+      id: "zelda",
+      title: "The Legend of Zelda and Religion",
+      status: "Edited Volume",
+      type: "Edited Volume",
+      tags: ["Games", "Religion", "Edited Volume"],
+      short:
+        "Zelda as theology—religion emerging from inside the game world.",
       description:
-        "Draws on ritual theory, liturgical studies, and ludology to articulate how Nintendo's series stages sacrificial imagination and heroic vocation.",
-      url: "./books.html#zelda-religion",
+        "An edited volume arguing that religious meaning in The Legend of Zelda arises from within the games themselves—mechanics, spaces, symbols, and narrative time—rather than from imported doctrine. Contributors treat ritual performance, sacred time and place, law and normativity, technology and landscape, player phenomenology, and theological motifs, making the case for games as genuine sites of theological reflection.",
+      url: "./projects.html#zelda",
       external: false
     }
   ];

--- a/js/projects.js
+++ b/js/projects.js
@@ -5,152 +5,40 @@
   const year = document.getElementById('year');
   if (year) year.textContent = new Date().getFullYear();
 
-  const projects = getProjects();
-  buildFilters(projects);
+  const cards = Array.from(document.querySelectorAll('.proj-card'));
+  if (!cards.length) return;
 
-  const state = { k: 'All', q: '' };
-  renderGrid(projects, state);
+  const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+  const reducedMotion = mediaQuery.matches;
 
-  const filters = document.getElementById('filters');
-  if (filters) {
-    filters.addEventListener('click', (event) => {
-      const btn = event.target.closest('button[data-k]');
-      if (!btn) return;
-      filters.querySelectorAll('button').forEach((b) => b.classList.remove('active'));
-      btn.classList.add('active');
-      state.k = btn.dataset.k || 'All';
-      renderGrid(projects, state);
+  const toggleClass = (card) => {
+    if (!card || reducedMotion) return;
+    card.classList.toggle('is-flipped');
+  };
+
+  document.addEventListener('click', (event) => {
+    const card = event.target.closest('.proj-card');
+    if (!card) return;
+    if (event.target.closest('a, button')) return;
+    toggleClass(card);
+  });
+
+  cards.forEach((card) => {
+    card.addEventListener('mouseleave', () => {
+      card.classList.remove('is-flipped');
     });
-  }
-
-  const search = document.getElementById('search');
-  if (search) {
-    search.addEventListener('input', (event) => {
-      state.q = event.target.value || '';
-      renderGrid(projects, state);
+    card.addEventListener('blur', () => {
+      card.classList.remove('is-flipped');
     });
-  }
-
-  function getProjects() {
-    const D = window.SITE_DATA || {};
-    const list = Array.isArray(D.projects) ? D.projects.slice() : window.PROJECTS || [];
-    return list.map((p) => ({
-      id: slugify(p.id || p.title || ''),
-      title: p.title || 'Untitled project',
-      status: p.status || p.type || 'Project',
-      type: p.type || '',
-      tags: Array.isArray(p.tags)
-        ? p.tags
-        : p.tags
-        ? String(p.tags)
-            .split(',')
-            .map((t) => t.trim())
-        : [],
-      date: p.date || p.started || '',
-      short: p.short || p.summary || '',
-      description: p.description || '',
-      url: p.url || null,
-      cover: p.cover || p.image || null,
-      external: !!p.external,
-    }));
-  }
-
-  function buildFilters(items) {
-    const node = document.getElementById('filters');
-    if (!node) return;
-    const kinds = new Set(['All']);
-    items.forEach((p) => {
-      if (p.status) kinds.add(p.status);
-      if (p.type) kinds.add(p.type);
+    card.addEventListener('keydown', (event) => {
+      if (event.key !== 'Enter' && event.key !== ' ') return;
+      event.preventDefault();
+      toggleClass(card);
     });
-    node.innerHTML = '';
-    Array.from(kinds).forEach((kind, idx) => {
-      const button = document.createElement('button');
-      button.type = 'button';
-      button.className = 'filter-btn' + (idx === 0 ? ' active' : '');
-      button.dataset.k = kind;
-      button.textContent = kind;
-      node.appendChild(button);
-    });
-  }
+  });
 
-  function renderGrid(items, { k = 'All', q = '' } = {}) {
-    const grid = document.getElementById('projects-grid');
-    const empty = document.getElementById('empty');
-    if (!grid) return;
-
-    const ql = q.trim().toLowerCase();
-    const filtered = items.filter((p) => {
-      const inKind = k === 'All' || p.status === k || p.type === k;
-      const haystack = [p.title, p.short, p.description, p.tags.join(' ')].join(' ').toLowerCase();
-      const inSearch = !ql || haystack.includes(ql);
-      return inKind && inSearch;
-    });
-
-    if (!filtered.length) {
-      grid.innerHTML = '';
-      if (empty) empty.style.display = 'block';
-      return;
-    }
-
-    if (empty) empty.style.display = 'none';
-    grid.innerHTML = '';
-
-    filtered.forEach((p) => {
-      const card = document.createElement('a');
-      card.className = 'card';
-      card.href = p.url || '#';
-      if (p.external) {
-        card.target = '_blank';
-        card.rel = 'noopener';
-      }
-      const tags = p.tags.length
-        ? `<div class="meta-row">${p.tags.map((tag) => `<span>${tag}</span>`).join('')}</div>`
-        : '';
-      card.innerHTML = `
-        ${motifMarkup(p.id)}
-        <span class="badge">${p.status || 'Research'}</span>
-        <h3>${p.title}</h3>
-        ${p.date ? `<p class="muted small">${formatDate(p.date)}</p>` : ''}
-        ${p.short ? `<p class="muted">${p.short}</p>` : ''}
-        ${p.description ? `<p class="muted small">${p.description}</p>` : ''}
-        ${tags}
-      `;
-      grid.appendChild(card);
-    });
-  }
-
-  function motifMarkup(id) {
-    const svg = (function () {
-      switch (id) {
-        case 'waypoint':
-          return '<svg viewBox="0 0 120 120"><circle cx="60" cy="60" r="40" /><path d="M60 24v72M24 60h72" /></svg>';
-        case 'zelda-religion':
-          return '<svg viewBox="0 0 120 120"><path d="M60 24l28 48H32z" /><path d="M60 24v48" /></svg>';
-        case 'pkd-theology-proj':
-        case 'pkd-theology':
-          return '<svg viewBox="0 0 120 120"><rect x="28" y="28" width="64" height="64" rx="6" /><path d="M28 60h64M60 28v64" /></svg>';
-        default:
-          return '<svg viewBox="0 0 120 120"><circle cx="60" cy="60" r="48" /><path d="M28 60h64M60 28v64" /></svg>';
-      }
-    })();
-    return `<span class="card__motif" aria-hidden="true">${svg}</span>`;
-  }
-
-  function slugify(value) {
-    return String(value || '')
-      .toLowerCase()
-      .trim()
-      .replace(/[^a-z0-9\s-]/g, '')
-      .replace(/\s+/g, '-')
-      .replace(/-+/g, '-');
-  }
-
-  function formatDate(value) {
-    try {
-      return new Date(value).toISOString().slice(0, 10);
-    } catch (err) {
-      return value;
-    }
-  }
+  document.addEventListener('keydown', (event) => {
+    if (event.key !== 'Escape') return;
+    cards.forEach((card) => card.classList.remove('is-flipped'));
+  });
 })();

--- a/projects.html
+++ b/projects.html
@@ -4,20 +4,8 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Projects — Michael C. Barros</title>
-  <meta name="description" content="Current research, collaborations, and media experiments exploring myth and the sacred." />
-  <link rel="stylesheet" href="./style.css" />
-  <style>
-    .filters-panel {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 0.8rem;
-      align-items: center;
-    }
-    .filters-panel input[type="search"] {
-      flex: 1 1 260px;
-      min-width: 220px;
-    }
-  </style>
+  <meta name="description" content="Waypoint Institute, The Legend of Zelda &amp; Religion, and an ABD dissertation on dream-based supernatural agents." />
+  <link rel="stylesheet" href="./style.css?v=20240607" />
 </head>
 <body class="page page--projects">
   <div class="shell">
@@ -40,35 +28,81 @@
         <p class="page-kicker">Current institutes, editorial collaborations, and theological studies examining sacred imagination in contemporary media.</p>
       </section>
 
-      <section class="section-card" aria-labelledby="proj-heading">
+      <section class="projects-section" aria-labelledby="projects-heading">
         <div class="section-heading">
-          <h2 id="proj-heading">Active research</h2>
-          <span class="muted small">Filter by status or theme to locate specific initiatives.</span>
+          <h2 id="projects-heading">Active initiatives</h2>
         </div>
-        <div class="filters-panel" role="group" aria-label="Filters">
-          <div id="filters" class="filters"></div>
-          <input id="search" type="search" placeholder="Search title, tags, or summary…" aria-label="Search projects" />
+        <p class="muted">Hover or tap each card to read the project overview.</p>
+
+        <div class="projects-grid" role="list">
+          <article class="proj-card" role="listitem" tabindex="0" id="waypoint">
+            <div class="proj-card-inner">
+              <div class="proj-card-face front">
+                <h3>Waypoint Institute</h3>
+                <p class="frontline">Tuition-free Christian education: great-books core, cohort-based, donor-supported.</p>
+              </div>
+              <div class="proj-card-face back">
+                <p class="blurb">
+                  Waypoint is a donor-supported, tuition-free Christian education project. We deliver a great-books core in Scripture,
+                  classical theology, and the liberal arts through online cohorts, clear syllabi, and a curated public-domain library.
+                  The emphasis is formation and rigorous study, with straightforward credit pathways for students who need them—so learners
+                  focus on reading, discussion, and service rather than cost or bureaucracy.
+                </p>
+              </div>
+            </div>
+          </article>
+
+          <article class="proj-card" role="listitem" tabindex="0" id="dissertation">
+            <div class="proj-card-inner">
+              <div class="proj-card-face front">
+                <h3>Formation of Supernatural Agents in Dreams Through Simulation</h3>
+                <p class="subtitle muted">A Grounded Cognition Perspective</p>
+                <p class="frontline">Dream simulation and belief—an embodied, grounded-cognition account.</p>
+              </div>
+              <div class="proj-card-face back">
+                <p class="blurb">
+                  My dissertation develops a grounded-cognition model of how dream simulations help people form and sustain concepts of
+                  supernatural agents. It operationalizes “simulation richness” (sensorimotor detail, agency, narrative) in dream reports
+                  and examines its relationship to religious and paranormal beliefs. The aim is a mechanistic, embodied alternative to
+                  simple “agency-detection” explanations in the cognitive science of religion.
+                </p>
+              </div>
+            </div>
+          </article>
+
+          <article class="proj-card" role="listitem" tabindex="0" id="zelda">
+            <div class="proj-card-inner">
+              <div class="proj-card-face front">
+                <h3>The Legend of Zelda and Religion</h3>
+                <p class="frontline">Zelda as theology—religion emerging from inside the game world.</p>
+              </div>
+              <div class="proj-card-face back">
+                <p class="blurb">
+                  An edited volume arguing that religious meaning in <em>The Legend of Zelda</em> arises from within the games themselves—
+                  mechanics, spaces, symbols, and narrative time—rather than from imported doctrine. Contributors treat ritual performance,
+                  sacred time and place, law and normativity, technology and landscape, player phenomenology, and theological motifs,
+                  making the case for games as genuine sites of theological reflection.
+                </p>
+              </div>
+            </div>
+          </article>
         </div>
-        <div id="projects-grid" class="grid cols-3" style="margin-top: 2rem;"></div>
-        <div id="empty" class="empty" style="display: none; margin-top: 1.5rem;">No projects match your filters yet—adjust the search or status.</div>
       </section>
     </main>
 
     <footer>
       <p class="footer-tagline">Religion · Media · Imagination</p>
       <nav class="footer-links" aria-label="Secondary">
-        <a href="./assets/docs/michael-c-barros-cv.pdf" target="_blank" rel="noopener">CV (PDF)</a>
         <a href="https://mythonoesis.substack.com/" target="_blank" rel="noopener">Substack</a>
-        <a href="https://github.com/michaelcbarros" target="_blank" rel="noopener">GitHub</a>
-        <a href="https://orcid.org/" target="_blank" rel="noopener">ORCID</a>
-        <a href="https://independent.academia.edu/MichaelBarros" target="_blank" rel="noopener">Academia.edu</a>
+        <a href="https://orcid.org/0000-0001-5462-8926" target="_blank" rel="noopener">ORCID</a>
+        <a href="https://national.academia.edu/MichaelBarros" target="_blank" rel="noopener">Academia.edu</a>
       </nav>
       © <span id="year"></span> Michael C. Barros
     </footer>
   </div>
 
-  <script defer src="./js/data/data.js"></script>
-  <script defer src="./js/nav.js"></script>
-  <script defer src="./js/projects.js"></script>
+  <script defer src="./js/data/data.js?v=20240607"></script>
+  <script defer src="./js/nav.js?v=20240607"></script>
+  <script defer src="./js/projects.js?v=20240607"></script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -281,70 +281,50 @@ a.nav__link::after {
 .hero {
   position: relative;
   margin-top: 72px;
-  display: grid;
-  gap: 3rem;
+  display: flex;
+  flex-direction: column;
   align-items: center;
+  gap: 2.4rem;
+  text-align: center;
 }
 
 .hero__content {
-  max-width: 560px;
-}
-
-@media (min-width: 960px) {
-  .hero {
-    grid-template-columns: minmax(0, 1.1fr) minmax(220px, 0.9fr);
-  }
+  max-width: 720px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.2rem;
 }
 
 .hero__content h1 {
   color: var(--ink);
-  max-width: 16ch;
 }
 
 .hero__tagline {
   font-size: 1.15rem;
-  max-width: 620px;
+  max-width: 720px;
   color: var(--muted);
 }
 
 .hero__meta {
-  margin-top: 1.4rem;
+  margin-top: 0.2rem;
   display: flex;
   flex-direction: column;
   gap: 1.1rem;
+  align-items: center;
 }
 
 .hero__meta .badge-row {
   display: flex;
   flex-wrap: wrap;
+  justify-content: center;
   gap: 0.55rem;
   font-size: 0.85rem;
   color: var(--subtle);
 }
 
-.hero__media {
-  position: relative;
-  width: min(380px, 100%);
-  justify-self: center;
-}
-
-.hero__motif {
-  position: relative;
-  width: 100%;
-  padding-bottom: 100%;
-  border-radius: 50%;
-  border: 1px solid var(--border);
-  background: transparent;
-}
-
-.hero__motif svg {
-  position: absolute;
-  inset: 12%;
-  width: 76%;
-  height: 76%;
-  opacity: 0.5;
-  stroke-width: 1;
-  stroke-linecap: square;
+.hero__meta .cta-row {
+  justify-content: center;
 }
 
 .badge {
@@ -417,6 +397,45 @@ a.nav__link::after {
   stroke: rgba(146, 153, 182, 0.55);
   stroke-linecap: square;
   stroke-linejoin: miter;
+}
+.card--waypoint {
+  background: linear-gradient(135deg, rgba(234, 245, 255, 0.95), rgba(204, 227, 255, 0.95));
+  border-color: rgba(122, 176, 221, 0.6);
+}
+.card--waypoint .card__motif svg {
+  stroke: rgba(48, 98, 142, 0.45);
+}
+.card--waypoint h3,
+.card--waypoint p,
+.card--waypoint .badge {
+  color: #0f2740;
+  border-color: rgba(15, 39, 64, 0.25);
+  background: rgba(255, 255, 255, 0.35);
+}
+.card--zelda {
+  background: radial-gradient(circle at 30% 30%, rgba(32, 74, 38, 0.9), rgba(18, 44, 24, 0.92));
+  border-color: rgba(116, 176, 92, 0.5);
+}
+.card--zelda .card__motif svg {
+  stroke: rgba(218, 200, 120, 0.7);
+  fill: rgba(218, 200, 120, 0.2);
+}
+.card--zelda h3,
+.card--zelda p,
+.card--zelda .badge {
+  color: rgba(237, 246, 238, 0.95);
+}
+.card--dissertation {
+  background: linear-gradient(160deg, rgba(34, 74, 129, 0.92), rgba(20, 48, 92, 0.92));
+  border-color: rgba(120, 170, 230, 0.5);
+}
+.card--dissertation .card__motif svg {
+  stroke: rgba(188, 216, 255, 0.65);
+}
+.card--dissertation h3,
+.card--dissertation p,
+.card--dissertation .badge {
+  color: rgba(233, 240, 252, 0.96);
 }
 
 .card:hover,
@@ -658,6 +677,141 @@ textarea:focus {
 
 address {
   font-style: normal;
+}
+
+.projects-section {
+  margin-top: 3rem;
+}
+
+.projects-grid {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin-top: 1.8rem;
+}
+
+@media (max-width: 1000px) {
+  .projects-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 640px) {
+  .projects-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.proj-card {
+  perspective: 1200px;
+  height: 320px;
+  scroll-margin-top: 6rem;
+}
+
+.proj-card-inner {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  transform-style: preserve-3d;
+  transition: transform 0.55s ease;
+}
+
+.proj-card:hover .proj-card-inner,
+.proj-card.is-flipped .proj-card-inner {
+  transform: rotateY(180deg);
+}
+
+.proj-card-face {
+  position: absolute;
+  inset: 0;
+  padding: 1.1rem 1.1rem 1rem;
+  border: 1px solid rgba(27, 34, 56, 0.9);
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.02);
+  backface-visibility: hidden;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  box-shadow: 0 18px 36px rgba(4, 6, 12, 0.55);
+}
+
+.proj-card-face.front h3 {
+  margin-bottom: 0.25rem;
+}
+
+.proj-card-face.front .subtitle {
+  margin: 0.1rem 0 0.5rem;
+  font-size: 0.95rem;
+}
+
+.proj-card-face.front .frontline {
+  margin-top: 0.35rem;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.proj-card-face.back {
+  transform: rotateY(180deg);
+}
+
+.proj-card-face.back .blurb {
+  font-size: 0.98rem;
+  line-height: 1.45;
+  display: -webkit-box;
+  -webkit-line-clamp: 8;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+#waypoint .proj-card-face.front {
+  background: linear-gradient(135deg, rgba(234, 245, 255, 0.95), rgba(204, 227, 255, 0.95));
+  border-color: rgba(122, 176, 221, 0.6);
+}
+
+#waypoint .proj-card-face.front h3,
+#waypoint .proj-card-face.front p {
+  color: #0f2740;
+}
+
+#dissertation .proj-card-face.front {
+  background: linear-gradient(160deg, rgba(34, 74, 129, 0.92), rgba(20, 48, 92, 0.92));
+  border-color: rgba(120, 170, 230, 0.5);
+}
+
+#dissertation .proj-card-face.front h3,
+#dissertation .proj-card-face.front p {
+  color: rgba(233, 240, 252, 0.96);
+}
+
+#dissertation .proj-card-face.front .subtitle {
+  color: rgba(210, 226, 255, 0.85);
+}
+
+#zelda .proj-card-face.front {
+  background: radial-gradient(circle at 30% 30%, rgba(32, 74, 38, 0.9), rgba(18, 44, 24, 0.92));
+  border-color: rgba(116, 176, 92, 0.5);
+}
+
+#zelda .proj-card-face.front h3,
+#zelda .proj-card-face.front p {
+  color: rgba(237, 246, 238, 0.95);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .proj-card-inner {
+    transition: none;
+  }
+
+  .proj-card:hover .proj-card-inner,
+  .proj-card.is-flipped .proj-card-inner {
+    transform: none;
+  }
+
+  .proj-card-face.back {
+    display: none;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
## Summary
- replace the Waypoint, dissertation, and Zelda project blurbs with the concise copy provided
- rebuild the projects page around hover/tap flip cards with keyboard and reduced-motion fallbacks
- trim the homepage project feed so it only surfaces the one-line summaries
- adjust the dissertation copy to explicitly reference the dissertation, align the project card fronts across pages, and update the Zelda badge text
- remove the redundant "Publication details" link from the books feature so the Read more toggle handles the extended copy
- center the homepage hero around the new “Scholar of religion & culture” headline, remove the motif graphic, and update badges to the requested fields
- match the about-page bio, quick facts, and site tagline data to the supplied copy while syncing the project card palettes across home and projects
- update the field label to say “Cognitive science of religion” wherever it appears
- emphasize training in psychology and theology across the hero and bio copy, remove the home “Current research focus” section, and streamline the approaches list to drop cultural history, reception/adaptation, and ethnography

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e30973b5d48330968481d0f8f59a18