### PR TITLE
Add era-organized reading list cover placeholders

### DIFF
--- a/reading-list.html
+++ b/reading-list.html
@@ -28,69 +28,588 @@
         <p class="page-kicker">Curated stacks of formative works drawn from the Western canon. Update the line-up or notes as reading priorities shift.</p>
       </section>
 
-      <section class="wrap reading-list">
-        <article class="reading-group" aria-labelledby="genre-theology">
-          <h2 id="genre-theology">Classical theology &amp; spirituality</h2>
-          <ul class="reading-items">
-            <li>
-              <span class="reading-title">Confessions</span>
-              <span class="reading-meta">Augustine of Hippo</span>
-              <p class="muted">Augustine’s prayerful autobiography framing memory, desire, and divine encounter.</p>
-            </li>
-            <li>
-              <span class="reading-title">The Ladder of Divine Ascent</span>
-              <span class="reading-meta">John Climacus</span>
-              <p class="muted">Monastic pedagogy on prayer, imagination, and the ascent toward virtue.</p>
-            </li>
-            <li>
-              <span class="reading-title">Institutes of the Christian Religion</span>
-              <span class="reading-meta">John Calvin</span>
-              <p class="muted">Systematic theology with rich treatments of devotion, scripture, and spiritual formation.</p>
-            </li>
-          </ul>
-        </article>
+      <section class="reading-catalog" aria-label="Reading list organized by era and genre">
+        <section class="reading-era" id="era-ancient" aria-labelledby="heading-ancient">
+          <div class="era-heading">
+            <h2 id="heading-ancient">Ancient</h2>
+            <p class="muted">Foundational texts from the classical world and near eastern imagination.</p>
+          </div>
 
-        <article class="reading-group" aria-labelledby="genre-philosophy">
-          <h2 id="genre-philosophy">Philosophy &amp; moral imagination</h2>
-          <ul class="reading-items">
-            <li>
-              <span class="reading-title">Nicomachean Ethics</span>
-              <span class="reading-meta">Aristotle</span>
-              <p class="muted">Virtue ethics and the cultivation of character through habituated practice.</p>
-            </li>
-            <li>
-              <span class="reading-title">Pensées</span>
-              <span class="reading-meta">Blaise Pascal</span>
-              <p class="muted">Fragmentary reflections bridging faith, reason, and the psychology of belief.</p>
-            </li>
-            <li>
-              <span class="reading-title">Leviathan</span>
-              <span class="reading-meta">Thomas Hobbes</span>
-              <p class="muted">Political theology and social imagination amid emerging modernity.</p>
-            </li>
-          </ul>
-        </article>
+          <div class="subgenre-grid">
+            <article class="reading-subgenre" id="ancient-literature" aria-labelledby="ancient-literature-title">
+              <h3 id="ancient-literature-title">Literature</h3>
+              <div class="cover-grid" role="group" aria-labelledby="ancient-literature-title">
+                <a class="cover-card" href="https://amzn.to/ancientlit01" target="_blank" rel="noopener" aria-label="The Iliad by Homer">
+                  <img src="./assets/img/iliad.png" alt="Cover of The Iliad" />
+                  <span class="sr-only">The Iliad — Homer</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/ancientlit02" target="_blank" rel="noopener" aria-label="The Odyssey by Homer">
+                  <img src="./assets/img/odyssey.png" alt="Cover of The Odyssey" />
+                  <span class="sr-only">The Odyssey — Homer</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/ancientlit03" target="_blank" rel="noopener" aria-label="Theogony and Works and Days by Hesiod">
+                  <img src="./assets/img/hesiod-theogony.png" alt="Cover of Theogony and Works and Days" />
+                  <span class="sr-only">Theogony and Works and Days — Hesiod</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/ancientlit04" target="_blank" rel="noopener" aria-label="Argonautica by Apollonius of Rhodes">
+                  <img src="./assets/img/argonautica.png" alt="Cover of Argonautica" />
+                  <span class="sr-only">Argonautica — Apollonius of Rhodes</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/ancientlit05" target="_blank" rel="noopener" aria-label="Odes by Pindar">
+                  <img src="./assets/img/pindar-odes.png" alt="Cover of Odes" />
+                  <span class="sr-only">Odes — Pindar</span>
+                </a>
+              </div>
+            </article>
 
-        <article class="reading-group" aria-labelledby="genre-literature">
-          <h2 id="genre-literature">Literature &amp; myth</h2>
-          <ul class="reading-items">
-            <li>
-              <span class="reading-title">The Divine Comedy</span>
-              <span class="reading-meta">Dante Alighieri</span>
-              <p class="muted">A pilgrimage through the afterlife mapping desire, judgment, and beatific vision.</p>
-            </li>
-            <li>
-              <span class="reading-title">The Iliad</span>
-              <span class="reading-meta">Homer</span>
-              <p class="muted">Epic imagination of honor, grief, and the divine amid war.</p>
-            </li>
-            <li>
-              <span class="reading-title">Paradise Lost</span>
-              <span class="reading-meta">John Milton</span>
-              <p class="muted">Cosmic drama of fall and redemption blending biblical epic with poetic innovation.</p>
-            </li>
-          </ul>
-        </article>
+            <article class="reading-subgenre" id="ancient-history" aria-labelledby="ancient-history-title">
+              <h3 id="ancient-history-title">History</h3>
+              <div class="cover-grid" role="group" aria-labelledby="ancient-history-title">
+                <a class="cover-card" href="https://amzn.to/ancienthist01" target="_blank" rel="noopener" aria-label="Histories by Herodotus">
+                  <img src="./assets/img/herodotus-histories.png" alt="Cover of Histories" />
+                  <span class="sr-only">Histories — Herodotus</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/ancienthist02" target="_blank" rel="noopener" aria-label="History of the Peloponnesian War by Thucydides">
+                  <img src="./assets/img/thucydides-peloponnesian-war.png" alt="Cover of History of the Peloponnesian War" />
+                  <span class="sr-only">History of the Peloponnesian War — Thucydides</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/ancienthist03" target="_blank" rel="noopener" aria-label="Anabasis by Xenophon">
+                  <img src="./assets/img/xenophon-anabasis.png" alt="Cover of Anabasis" />
+                  <span class="sr-only">Anabasis — Xenophon</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/ancienthist04" target="_blank" rel="noopener" aria-label="Parallel Lives by Plutarch">
+                  <img src="./assets/img/plutarch-parallel-lives.png" alt="Cover of Parallel Lives" />
+                  <span class="sr-only">Parallel Lives — Plutarch</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/ancienthist05" target="_blank" rel="noopener" aria-label="The Twelve Caesars by Suetonius">
+                  <img src="./assets/img/suetonius-twelve-caesars.png" alt="Cover of The Twelve Caesars" />
+                  <span class="sr-only">The Twelve Caesars — Suetonius</span>
+                </a>
+              </div>
+            </article>
+
+            <article class="reading-subgenre" id="ancient-theology" aria-labelledby="ancient-theology-title">
+              <h3 id="ancient-theology-title">Theology</h3>
+              <div class="cover-grid" role="group" aria-labelledby="ancient-theology-title">
+                <a class="cover-card" href="https://amzn.to/ancienttheo01" target="_blank" rel="noopener" aria-label="Enuma Elish">
+                  <img src="./assets/img/enuma-elish.png" alt="Cover of Enuma Elish" />
+                  <span class="sr-only">Enuma Elish — Babylonian Creation Epic</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/ancienttheo02" target="_blank" rel="noopener" aria-label="The Egyptian Book of the Dead">
+                  <img src="./assets/img/book-of-the-dead.png" alt="Cover of The Egyptian Book of the Dead" />
+                  <span class="sr-only">The Egyptian Book of the Dead — trans. E. A. Wallis Budge</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/ancienttheo03" target="_blank" rel="noopener" aria-label="On the Gods and the World by Sallustius">
+                  <img src="./assets/img/sallustius-on-the-gods.png" alt="Cover of On the Gods and the World" />
+                  <span class="sr-only">On the Gods and the World — Sallustius</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/ancienttheo04" target="_blank" rel="noopener" aria-label="The Enneads by Plotinus">
+                  <img src="./assets/img/plotinus-enneads.png" alt="Cover of The Enneads" />
+                  <span class="sr-only">The Enneads — Plotinus</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/ancienttheo05" target="_blank" rel="noopener" aria-label="On the Nature of the Gods by Cicero">
+                  <img src="./assets/img/cicero-on-the-nature-of-the-gods.png" alt="Cover of On the Nature of the Gods" />
+                  <span class="sr-only">On the Nature of the Gods — Cicero</span>
+                </a>
+              </div>
+            </article>
+
+            <article class="reading-subgenre" id="ancient-fiction" aria-labelledby="ancient-fiction-title">
+              <h3 id="ancient-fiction-title">Fiction &amp; mythic tales</h3>
+              <div class="cover-grid" role="group" aria-labelledby="ancient-fiction-title">
+                <a class="cover-card" href="https://amzn.to/ancientfic01" target="_blank" rel="noopener" aria-label="Metamorphoses by Ovid">
+                  <img src="./assets/img/ovid-metamorphoses.png" alt="Cover of Metamorphoses" />
+                  <span class="sr-only">Metamorphoses — Ovid</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/ancientfic02" target="_blank" rel="noopener" aria-label="Daphnis and Chloe by Longus">
+                  <img src="./assets/img/longus-daphnis-chloe.png" alt="Cover of Daphnis and Chloe" />
+                  <span class="sr-only">Daphnis and Chloe — Longus</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/ancientfic03" target="_blank" rel="noopener" aria-label="Aesop's Fables">
+                  <img src="./assets/img/aesop-fables.png" alt="Cover of Aesop's Fables" />
+                  <span class="sr-only">Aesop's Fables — Aesop</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/ancientfic04" target="_blank" rel="noopener" aria-label="The Golden Ass by Apuleius">
+                  <img src="./assets/img/apuleius-golden-ass.png" alt="Cover of The Golden Ass" />
+                  <span class="sr-only">The Golden Ass — Apuleius</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/ancientfic05" target="_blank" rel="noopener" aria-label="True History by Lucian">
+                  <img src="./assets/img/lucian-true-history.png" alt="Cover of True History" />
+                  <span class="sr-only">True History — Lucian</span>
+                </a>
+              </div>
+            </article>
+
+            <article class="reading-subgenre" id="ancient-philosophy" aria-labelledby="ancient-philosophy-title">
+              <h3 id="ancient-philosophy-title">Philosophy</h3>
+              <div class="cover-grid" role="group" aria-labelledby="ancient-philosophy-title">
+                <a class="cover-card" href="https://amzn.to/ancientphil01" target="_blank" rel="noopener" aria-label="Republic by Plato">
+                  <img src="./assets/img/plato-republic.png" alt="Cover of Republic" />
+                  <span class="sr-only">Republic — Plato</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/ancientphil02" target="_blank" rel="noopener" aria-label="Nicomachean Ethics by Aristotle">
+                  <img src="./assets/img/aristotle-nicomachean-ethics.png" alt="Cover of Nicomachean Ethics" />
+                  <span class="sr-only">Nicomachean Ethics — Aristotle</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/ancientphil03" target="_blank" rel="noopener" aria-label="Meditations by Marcus Aurelius">
+                  <img src="./assets/img/marcus-aurelius-meditations.png" alt="Cover of Meditations" />
+                  <span class="sr-only">Meditations — Marcus Aurelius</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/ancientphil04" target="_blank" rel="noopener" aria-label="Enchiridion by Epictetus">
+                  <img src="./assets/img/epictetus-enchiridion.png" alt="Cover of Enchiridion" />
+                  <span class="sr-only">Enchiridion — Epictetus</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/ancientphil05" target="_blank" rel="noopener" aria-label="On the Nature of Things by Lucretius">
+                  <img src="./assets/img/lucretius-on-the-nature-of-things.png" alt="Cover of On the Nature of Things" />
+                  <span class="sr-only">On the Nature of Things — Lucretius</span>
+                </a>
+              </div>
+            </article>
+          </div>
+        </section>
+
+        <section class="reading-era" id="era-medieval" aria-labelledby="heading-medieval">
+          <div class="era-heading">
+            <h2 id="heading-medieval">Medieval</h2>
+            <p class="muted">Monastic, scholastic, and courtly voices from the middle ages.</p>
+          </div>
+
+          <div class="subgenre-grid">
+            <article class="reading-subgenre" id="medieval-literature" aria-labelledby="medieval-literature-title">
+              <h3 id="medieval-literature-title">Literature</h3>
+              <div class="cover-grid" role="group" aria-labelledby="medieval-literature-title">
+                <a class="cover-card" href="https://amzn.to/medievallit01" target="_blank" rel="noopener" aria-label="Beowulf">
+                  <img src="./assets/img/beowulf.png" alt="Cover of Beowulf" />
+                  <span class="sr-only">Beowulf — translated by Seamus Heaney</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/medievallit02" target="_blank" rel="noopener" aria-label="The Song of Roland">
+                  <img src="./assets/img/song-of-roland.png" alt="Cover of The Song of Roland" />
+                  <span class="sr-only">The Song of Roland — Anonymous</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/medievallit03" target="_blank" rel="noopener" aria-label="The Nibelungenlied">
+                  <img src="./assets/img/nibelungenlied.png" alt="Cover of The Nibelungenlied" />
+                  <span class="sr-only">The Nibelungenlied — Anonymous</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/medievallit04" target="_blank" rel="noopener" aria-label="The Canterbury Tales by Geoffrey Chaucer">
+                  <img src="./assets/img/canterbury-tales.png" alt="Cover of The Canterbury Tales" />
+                  <span class="sr-only">The Canterbury Tales — Geoffrey Chaucer</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/medievallit05" target="_blank" rel="noopener" aria-label="The Poem of the Cid">
+                  <img src="./assets/img/poem-of-the-cid.png" alt="Cover of The Poem of the Cid" />
+                  <span class="sr-only">The Poem of the Cid — Anonymous</span>
+                </a>
+              </div>
+            </article>
+
+            <article class="reading-subgenre" id="medieval-history" aria-labelledby="medieval-history-title">
+              <h3 id="medieval-history-title">History</h3>
+              <div class="cover-grid" role="group" aria-labelledby="medieval-history-title">
+                <a class="cover-card" href="https://amzn.to/medievalhist01" target="_blank" rel="noopener" aria-label="Ecclesiastical History of the English People by Bede">
+                  <img src="./assets/img/bede-ecclesiastical-history.png" alt="Cover of Ecclesiastical History of the English People" />
+                  <span class="sr-only">Ecclesiastical History of the English People — Bede</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/medievalhist02" target="_blank" rel="noopener" aria-label="The Alexiad by Anna Komnene">
+                  <img src="./assets/img/anna-komnene-alexiad.png" alt="Cover of The Alexiad" />
+                  <span class="sr-only">The Alexiad — Anna Komnene</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/medievalhist03" target="_blank" rel="noopener" aria-label="Chronicle of the Crusades">
+                  <img src="./assets/img/chronicle-of-the-crusades.png" alt="Cover of Chronicle of the Crusades" />
+                  <span class="sr-only">Chronicle of the Crusades — Joinville &amp; Villehardouin</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/medievalhist04" target="_blank" rel="noopener" aria-label="Magna Carta">
+                  <img src="./assets/img/magna-carta.png" alt="Cover of Magna Carta" />
+                  <span class="sr-only">Magna Carta — foundational charter</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/medievalhist05" target="_blank" rel="noopener" aria-label="Heimskringla by Snorri Sturluson">
+                  <img src="./assets/img/heimskringla.png" alt="Cover of Heimskringla" />
+                  <span class="sr-only">Heimskringla — Snorri Sturluson</span>
+                </a>
+              </div>
+            </article>
+
+            <article class="reading-subgenre" id="medieval-theology" aria-labelledby="medieval-theology-title">
+              <h3 id="medieval-theology-title">Theology</h3>
+              <div class="cover-grid" role="group" aria-labelledby="medieval-theology-title">
+                <a class="cover-card" href="https://amzn.to/medievaltheo01" target="_blank" rel="noopener" aria-label="Summa Theologiae by Thomas Aquinas">
+                  <img src="./assets/img/aquinas-summa-theologiae.png" alt="Cover of Summa Theologiae" />
+                  <span class="sr-only">Summa Theologiae — Thomas Aquinas</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/medievaltheo02" target="_blank" rel="noopener" aria-label="The Cloud of Unknowing">
+                  <img src="./assets/img/cloud-of-unknowing.png" alt="Cover of The Cloud of Unknowing" />
+                  <span class="sr-only">The Cloud of Unknowing — Anonymous</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/medievaltheo03" target="_blank" rel="noopener" aria-label="The Imitation of Christ by Thomas à Kempis">
+                  <img src="./assets/img/imitation-of-christ.png" alt="Cover of The Imitation of Christ" />
+                  <span class="sr-only">The Imitation of Christ — Thomas à Kempis</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/medievaltheo04" target="_blank" rel="noopener" aria-label="The Mystical Theology by Pseudo-Dionysius">
+                  <img src="./assets/img/pseudo-dionysius-mystical-theology.png" alt="Cover of The Mystical Theology" />
+                  <span class="sr-only">The Mystical Theology — Pseudo-Dionysius the Areopagite</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/medievaltheo05" target="_blank" rel="noopener" aria-label="Commentary on the Sentences by Bonaventure">
+                  <img src="./assets/img/bonaventure-sentences.png" alt="Cover of Commentary on the Sentences" />
+                  <span class="sr-only">Commentary on the Sentences — Bonaventure</span>
+                </a>
+              </div>
+            </article>
+
+            <article class="reading-subgenre" id="medieval-fiction" aria-labelledby="medieval-fiction-title">
+              <h3 id="medieval-fiction-title">Fiction &amp; romance</h3>
+              <div class="cover-grid" role="group" aria-labelledby="medieval-fiction-title">
+                <a class="cover-card" href="https://amzn.to/medievalfic01" target="_blank" rel="noopener" aria-label="Sir Gawain and the Green Knight">
+                  <img src="./assets/img/sir-gawain.png" alt="Cover of Sir Gawain and the Green Knight" />
+                  <span class="sr-only">Sir Gawain and the Green Knight — Anonymous</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/medievalfic02" target="_blank" rel="noopener" aria-label="Le Morte d'Arthur by Thomas Malory">
+                  <img src="./assets/img/le-morte-darthur.png" alt="Cover of Le Morte d'Arthur" />
+                  <span class="sr-only">Le Morte d'Arthur — Thomas Malory</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/medievalfic03" target="_blank" rel="noopener" aria-label="The Travels of Sir John Mandeville">
+                  <img src="./assets/img/john-mandeville-travels.png" alt="Cover of The Travels of Sir John Mandeville" />
+                  <span class="sr-only">The Travels of Sir John Mandeville — Anonymous</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/medievalfic04" target="_blank" rel="noopener" aria-label="The Decameron by Giovanni Boccaccio">
+                  <img src="./assets/img/boccaccio-decameron.png" alt="Cover of The Decameron" />
+                  <span class="sr-only">The Decameron — Giovanni Boccaccio</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/medievalfic05" target="_blank" rel="noopener" aria-label="The Book of the City of Ladies by Christine de Pizan">
+                  <img src="./assets/img/city-of-ladies.png" alt="Cover of The Book of the City of Ladies" />
+                  <span class="sr-only">The Book of the City of Ladies — Christine de Pizan</span>
+                </a>
+              </div>
+            </article>
+
+            <article class="reading-subgenre" id="medieval-philosophy" aria-labelledby="medieval-philosophy-title">
+              <h3 id="medieval-philosophy-title">Philosophy</h3>
+              <div class="cover-grid" role="group" aria-labelledby="medieval-philosophy-title">
+                <a class="cover-card" href="https://amzn.to/medievalphil01" target="_blank" rel="noopener" aria-label="Proslogion by Anselm of Canterbury">
+                  <img src="./assets/img/anselm-proslogion.png" alt="Cover of Proslogion" />
+                  <span class="sr-only">Proslogion — Anselm of Canterbury</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/medievalphil02" target="_blank" rel="noopener" aria-label="The Consolation of Philosophy by Boethius">
+                  <img src="./assets/img/boethius-consolation.png" alt="Cover of The Consolation of Philosophy" />
+                  <span class="sr-only">The Consolation of Philosophy — Boethius</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/medievalphil03" target="_blank" rel="noopener" aria-label="The Guide for the Perplexed by Maimonides">
+                  <img src="./assets/img/maimonides-guide.png" alt="Cover of The Guide for the Perplexed" />
+                  <span class="sr-only">The Guide for the Perplexed — Maimonides</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/medievalphil04" target="_blank" rel="noopener" aria-label="Summa Contra Gentiles by Thomas Aquinas">
+                  <img src="./assets/img/aquinas-summa-contra-gentiles.png" alt="Cover of Summa Contra Gentiles" />
+                  <span class="sr-only">Summa Contra Gentiles — Thomas Aquinas</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/medievalphil05" target="_blank" rel="noopener" aria-label="The Incoherence of the Incoherence by Averroes">
+                  <img src="./assets/img/averroes-incoherence.png" alt="Cover of The Incoherence of the Incoherence" />
+                  <span class="sr-only">The Incoherence of the Incoherence — Averroes</span>
+                </a>
+              </div>
+            </article>
+          </div>
+        </section>
+
+        <section class="reading-era" id="era-modern" aria-labelledby="heading-modern">
+          <div class="era-heading">
+            <h2 id="heading-modern">Modern</h2>
+            <p class="muted">Renaissance through nineteenth-century currents reshaping the West.</p>
+          </div>
+
+          <div class="subgenre-grid">
+            <article class="reading-subgenre" id="modern-literature" aria-labelledby="modern-literature-title">
+              <h3 id="modern-literature-title">Literature</h3>
+              <div class="cover-grid" role="group" aria-labelledby="modern-literature-title">
+                <a class="cover-card" href="https://amzn.to/modernlit01" target="_blank" rel="noopener" aria-label="Don Quixote by Miguel de Cervantes">
+                  <img src="./assets/img/don-quixote.png" alt="Cover of Don Quixote" />
+                  <span class="sr-only">Don Quixote — Miguel de Cervantes</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/modernlit02" target="_blank" rel="noopener" aria-label="Paradise Lost by John Milton">
+                  <img src="./assets/img/paradise-lost.png" alt="Cover of Paradise Lost" />
+                  <span class="sr-only">Paradise Lost — John Milton</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/modernlit03" target="_blank" rel="noopener" aria-label="Faust by Johann Wolfgang von Goethe">
+                  <img src="./assets/img/goethe-faust.png" alt="Cover of Faust" />
+                  <span class="sr-only">Faust — Johann Wolfgang von Goethe</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/modernlit04" target="_blank" rel="noopener" aria-label="Pride and Prejudice by Jane Austen">
+                  <img src="./assets/img/pride-and-prejudice.png" alt="Cover of Pride and Prejudice" />
+                  <span class="sr-only">Pride and Prejudice — Jane Austen</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/modernlit05" target="_blank" rel="noopener" aria-label="Moby-Dick by Herman Melville">
+                  <img src="./assets/img/moby-dick.png" alt="Cover of Moby-Dick" />
+                  <span class="sr-only">Moby-Dick — Herman Melville</span>
+                </a>
+              </div>
+            </article>
+
+            <article class="reading-subgenre" id="modern-history" aria-labelledby="modern-history-title">
+              <h3 id="modern-history-title">History</h3>
+              <div class="cover-grid" role="group" aria-labelledby="modern-history-title">
+                <a class="cover-card" href="https://amzn.to/modernhist01" target="_blank" rel="noopener" aria-label="The Decline and Fall of the Roman Empire by Edward Gibbon">
+                  <img src="./assets/img/gibbon-decline-fall.png" alt="Cover of The History of the Decline and Fall of the Roman Empire" />
+                  <span class="sr-only">The History of the Decline and Fall of the Roman Empire — Edward Gibbon</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/modernhist02" target="_blank" rel="noopener" aria-label="The Federalist Papers">
+                  <img src="./assets/img/federalist-papers.png" alt="Cover of The Federalist Papers" />
+                  <span class="sr-only">The Federalist Papers — Hamilton, Madison, and Jay</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/modernhist03" target="_blank" rel="noopener" aria-label="The Rights of Man by Thomas Paine">
+                  <img src="./assets/img/thomas-paine-rights-of-man.png" alt="Cover of The Rights of Man" />
+                  <span class="sr-only">The Rights of Man — Thomas Paine</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/modernhist04" target="_blank" rel="noopener" aria-label="Democracy in America by Alexis de Tocqueville">
+                  <img src="./assets/img/tocqueville-democracy-in-america.png" alt="Cover of Democracy in America" />
+                  <span class="sr-only">Democracy in America — Alexis de Tocqueville</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/modernhist05" target="_blank" rel="noopener" aria-label="The French Revolution by Thomas Carlyle">
+                  <img src="./assets/img/carlyle-french-revolution.png" alt="Cover of The French Revolution" />
+                  <span class="sr-only">The French Revolution — Thomas Carlyle</span>
+                </a>
+              </div>
+            </article>
+
+            <article class="reading-subgenre" id="modern-theology" aria-labelledby="modern-theology-title">
+              <h3 id="modern-theology-title">Theology</h3>
+              <div class="cover-grid" role="group" aria-labelledby="modern-theology-title">
+                <a class="cover-card" href="https://amzn.to/moderntheo01" target="_blank" rel="noopener" aria-label="Institutes of the Christian Religion by John Calvin">
+                  <img src="./assets/img/calvin-institutes.png" alt="Cover of Institutes of the Christian Religion" />
+                  <span class="sr-only">Institutes of the Christian Religion — John Calvin</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/moderntheo02" target="_blank" rel="noopener" aria-label="Pensées by Blaise Pascal">
+                  <img src="./assets/img/pascal-pensees.png" alt="Cover of Pensées" />
+                  <span class="sr-only">Pensées — Blaise Pascal</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/moderntheo03" target="_blank" rel="noopener" aria-label="Parochial and Plain Sermons by John Henry Newman">
+                  <img src="./assets/img/newman-sermons.png" alt="Cover of Parochial and Plain Sermons" />
+                  <span class="sr-only">Parochial and Plain Sermons — John Henry Newman</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/moderntheo04" target="_blank" rel="noopener" aria-label="Orthodoxy by G. K. Chesterton">
+                  <img src="./assets/img/chesterton-orthodoxy.png" alt="Cover of Orthodoxy" />
+                  <span class="sr-only">Orthodoxy — G. K. Chesterton</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/moderntheo05" target="_blank" rel="noopener" aria-label="The Philokalia">
+                  <img src="./assets/img/philokalia.png" alt="Cover of The Philokalia" />
+                  <span class="sr-only">The Philokalia — St. Nikodimos &amp; St. Makarios (editors)</span>
+                </a>
+              </div>
+            </article>
+
+            <article class="reading-subgenre" id="modern-fiction" aria-labelledby="modern-fiction-title">
+              <h3 id="modern-fiction-title">Fiction</h3>
+              <div class="cover-grid" role="group" aria-labelledby="modern-fiction-title">
+                <a class="cover-card" href="https://amzn.to/modernfic01" target="_blank" rel="noopener" aria-label="Frankenstein by Mary Shelley">
+                  <img src="./assets/img/frankenstein.png" alt="Cover of Frankenstein" />
+                  <span class="sr-only">Frankenstein — Mary Shelley</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/modernfic02" target="_blank" rel="noopener" aria-label="Wuthering Heights by Emily Brontë">
+                  <img src="./assets/img/wuthering-heights.png" alt="Cover of Wuthering Heights" />
+                  <span class="sr-only">Wuthering Heights — Emily Brontë</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/modernfic03" target="_blank" rel="noopener" aria-label="Crime and Punishment by Fyodor Dostoevsky">
+                  <img src="./assets/img/crime-and-punishment.png" alt="Cover of Crime and Punishment" />
+                  <span class="sr-only">Crime and Punishment — Fyodor Dostoevsky</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/modernfic04" target="_blank" rel="noopener" aria-label="The Scarlet Letter by Nathaniel Hawthorne">
+                  <img src="./assets/img/scarlet-letter.png" alt="Cover of The Scarlet Letter" />
+                  <span class="sr-only">The Scarlet Letter — Nathaniel Hawthorne</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/modernfic05" target="_blank" rel="noopener" aria-label="Les Misérables by Victor Hugo">
+                  <img src="./assets/img/les-miserables.png" alt="Cover of Les Misérables" />
+                  <span class="sr-only">Les Misérables — Victor Hugo</span>
+                </a>
+              </div>
+            </article>
+
+            <article class="reading-subgenre" id="modern-philosophy" aria-labelledby="modern-philosophy-title">
+              <h3 id="modern-philosophy-title">Philosophy</h3>
+              <div class="cover-grid" role="group" aria-labelledby="modern-philosophy-title">
+                <a class="cover-card" href="https://amzn.to/modernphil01" target="_blank" rel="noopener" aria-label="Discourse on Method by René Descartes">
+                  <img src="./assets/img/descartes-discourse.png" alt="Cover of Discourse on Method" />
+                  <span class="sr-only">Discourse on Method — René Descartes</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/modernphil02" target="_blank" rel="noopener" aria-label="Ethics by Baruch Spinoza">
+                  <img src="./assets/img/spinoza-ethics.png" alt="Cover of Ethics" />
+                  <span class="sr-only">Ethics — Baruch Spinoza</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/modernphil03" target="_blank" rel="noopener" aria-label="Critique of Pure Reason by Immanuel Kant">
+                  <img src="./assets/img/kant-critique-of-pure-reason.png" alt="Cover of Critique of Pure Reason" />
+                  <span class="sr-only">Critique of Pure Reason — Immanuel Kant</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/modernphil04" target="_blank" rel="noopener" aria-label="Phenomenology of Spirit by G. W. F. Hegel">
+                  <img src="./assets/img/hegel-phenomenology-of-spirit.png" alt="Cover of Phenomenology of Spirit" />
+                  <span class="sr-only">Phenomenology of Spirit — G. W. F. Hegel</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/modernphil05" target="_blank" rel="noopener" aria-label="Utilitarianism by John Stuart Mill">
+                  <img src="./assets/img/mill-utilitarianism.png" alt="Cover of Utilitarianism" />
+                  <span class="sr-only">Utilitarianism — John Stuart Mill</span>
+                </a>
+              </div>
+            </article>
+          </div>
+        </section>
+
+        <section class="reading-era" id="era-contemporary" aria-labelledby="heading-contemporary">
+          <div class="era-heading">
+            <h2 id="heading-contemporary">Contemporary</h2>
+            <p class="muted">Twentieth and twenty-first century voices engaging modern dilemmas.</p>
+          </div>
+
+          <div class="subgenre-grid">
+            <article class="reading-subgenre" id="contemporary-literature" aria-labelledby="contemporary-literature-title">
+              <h3 id="contemporary-literature-title">Literature</h3>
+              <div class="cover-grid" role="group" aria-labelledby="contemporary-literature-title">
+                <a class="cover-card" href="https://amzn.to/contemporarylit01" target="_blank" rel="noopener" aria-label="The Waste Land by T. S. Eliot">
+                  <img src="./assets/img/eliot-waste-land.png" alt="Cover of The Waste Land" />
+                  <span class="sr-only">The Waste Land — T. S. Eliot</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/contemporarylit02" target="_blank" rel="noopener" aria-label="One Hundred Years of Solitude by Gabriel García Márquez">
+                  <img src="./assets/img/marquez-one-hundred-years.png" alt="Cover of One Hundred Years of Solitude" />
+                  <span class="sr-only">One Hundred Years of Solitude — Gabriel García Márquez</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/contemporarylit03" target="_blank" rel="noopener" aria-label="Beloved by Toni Morrison">
+                  <img src="./assets/img/toni-morrison-beloved.png" alt="Cover of Beloved" />
+                  <span class="sr-only">Beloved — Toni Morrison</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/contemporarylit04" target="_blank" rel="noopener" aria-label="The Name of the Rose by Umberto Eco">
+                  <img src="./assets/img/eco-name-of-the-rose.png" alt="Cover of The Name of the Rose" />
+                  <span class="sr-only">The Name of the Rose — Umberto Eco</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/contemporarylit05" target="_blank" rel="noopener" aria-label="Midnight's Children by Salman Rushdie">
+                  <img src="./assets/img/rushdie-midnights-children.png" alt="Cover of Midnight's Children" />
+                  <span class="sr-only">Midnight's Children — Salman Rushdie</span>
+                </a>
+              </div>
+            </article>
+
+            <article class="reading-subgenre" id="contemporary-history" aria-labelledby="contemporary-history-title">
+              <h3 id="contemporary-history-title">History</h3>
+              <div class="cover-grid" role="group" aria-labelledby="contemporary-history-title">
+                <a class="cover-card" href="https://amzn.to/contemporaryhist01" target="_blank" rel="noopener" aria-label="The Guns of August by Barbara Tuchman">
+                  <img src="./assets/img/tuchman-guns-of-august.png" alt="Cover of The Guns of August" />
+                  <span class="sr-only">The Guns of August — Barbara Tuchman</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/contemporaryhist02" target="_blank" rel="noopener" aria-label="Postwar by Tony Judt">
+                  <img src="./assets/img/tony-judt-postwar.png" alt="Cover of Postwar" />
+                  <span class="sr-only">Postwar — Tony Judt</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/contemporaryhist03" target="_blank" rel="noopener" aria-label="The Clash of Civilizations by Samuel P. Huntington">
+                  <img src="./assets/img/huntington-clash-of-civilizations.png" alt="Cover of The Clash of Civilizations" />
+                  <span class="sr-only">The Clash of Civilizations — Samuel P. Huntington</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/contemporaryhist04" target="_blank" rel="noopener" aria-label="The Cold War by John Lewis Gaddis">
+                  <img src="./assets/img/gaddis-cold-war.png" alt="Cover of The Cold War" />
+                  <span class="sr-only">The Cold War — John Lewis Gaddis</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/contemporaryhist05" target="_blank" rel="noopener" aria-label="A People's History of the United States by Howard Zinn">
+                  <img src="./assets/img/zinn-peoples-history.png" alt="Cover of A People's History of the United States" />
+                  <span class="sr-only">A People's History of the United States — Howard Zinn</span>
+                </a>
+              </div>
+            </article>
+
+            <article class="reading-subgenre" id="contemporary-theology" aria-labelledby="contemporary-theology-title">
+              <h3 id="contemporary-theology-title">Theology</h3>
+              <div class="cover-grid" role="group" aria-labelledby="contemporary-theology-title">
+                <a class="cover-card" href="https://amzn.to/contemporarytheo01" target="_blank" rel="noopener" aria-label="Theology of the Body by John Paul II">
+                  <img src="./assets/img/john-paul-ii-theology-of-the-body.png" alt="Cover of Theology of the Body" />
+                  <span class="sr-only">Theology of the Body — John Paul II</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/contemporarytheo02" target="_blank" rel="noopener" aria-label="God in the Dock by C. S. Lewis">
+                  <img src="./assets/img/cs-lewis-god-in-the-dock.png" alt="Cover of God in the Dock" />
+                  <span class="sr-only">God in the Dock — C. S. Lewis</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/contemporarytheo03" target="_blank" rel="noopener" aria-label="The Spirit of the Liturgy by Joseph Ratzinger">
+                  <img src="./assets/img/ratzinger-spirit-of-the-liturgy.png" alt="Cover of The Spirit of the Liturgy" />
+                  <span class="sr-only">The Spirit of the Liturgy — Joseph Ratzinger</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/contemporarytheo04" target="_blank" rel="noopener" aria-label="Evangelii Nuntiandi by Pope Paul VI">
+                  <img src="./assets/img/paul-vi-evangelii-nuntiandi.png" alt="Cover of Evangelii Nuntiandi" />
+                  <span class="sr-only">Evangelii Nuntiandi — Pope Paul VI</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/contemporarytheo05" target="_blank" rel="noopener" aria-label="Mysterium Paschale by Hans Urs von Balthasar">
+                  <img src="./assets/img/balthasar-mysterium-paschale.png" alt="Cover of Mysterium Paschale" />
+                  <span class="sr-only">Mysterium Paschale — Hans Urs von Balthasar</span>
+                </a>
+              </div>
+            </article>
+
+            <article class="reading-subgenre" id="contemporary-fiction" aria-labelledby="contemporary-fiction-title">
+              <h3 id="contemporary-fiction-title">Fiction &amp; speculative</h3>
+              <div class="cover-grid" role="group" aria-labelledby="contemporary-fiction-title">
+                <a class="cover-card" href="https://amzn.to/contemporaryfic01" target="_blank" rel="noopener" aria-label="The Lord of the Rings by J. R. R. Tolkien">
+                  <img src="./assets/img/tolkien-lord-of-the-rings.png" alt="Cover of The Lord of the Rings" />
+                  <span class="sr-only">The Lord of the Rings — J. R. R. Tolkien</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/contemporaryfic02" target="_blank" rel="noopener" aria-label="Dune by Frank Herbert">
+                  <img src="./assets/img/frank-herbert-dune.png" alt="Cover of Dune" />
+                  <span class="sr-only">Dune — Frank Herbert</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/contemporaryfic03" target="_blank" rel="noopener" aria-label="The Left Hand of Darkness by Ursula K. Le Guin">
+                  <img src="./assets/img/le-guin-left-hand-of-darkness.png" alt="Cover of The Left Hand of Darkness" />
+                  <span class="sr-only">The Left Hand of Darkness — Ursula K. Le Guin</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/contemporaryfic04" target="_blank" rel="noopener" aria-label="A Wrinkle in Time by Madeleine L'Engle">
+                  <img src="./assets/img/a-wrinkle-in-time.png" alt="Cover of A Wrinkle in Time" />
+                  <span class="sr-only">A Wrinkle in Time — Madeleine L'Engle</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/contemporaryfic05" target="_blank" rel="noopener" aria-label="The Chronicles of Narnia by C. S. Lewis">
+                  <img src="./assets/img/cs-lewis-narnia.png" alt="Cover of The Chronicles of Narnia" />
+                  <span class="sr-only">The Chronicles of Narnia — C. S. Lewis</span>
+                </a>
+              </div>
+            </article>
+
+            <article class="reading-subgenre" id="contemporary-philosophy" aria-labelledby="contemporary-philosophy-title">
+              <h3 id="contemporary-philosophy-title">Philosophy</h3>
+              <div class="cover-grid" role="group" aria-labelledby="contemporary-philosophy-title">
+                <a class="cover-card" href="https://amzn.to/contemporaryphil01" target="_blank" rel="noopener" aria-label="Being and Time by Martin Heidegger">
+                  <img src="./assets/img/heidegger-being-and-time.png" alt="Cover of Being and Time" />
+                  <span class="sr-only">Being and Time — Martin Heidegger</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/contemporaryphil02" target="_blank" rel="noopener" aria-label="Philosophical Investigations by Ludwig Wittgenstein">
+                  <img src="./assets/img/wittgenstein-philosophical-investigations.png" alt="Cover of Philosophical Investigations" />
+                  <span class="sr-only">Philosophical Investigations — Ludwig Wittgenstein</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/contemporaryphil03" target="_blank" rel="noopener" aria-label="The Rebel by Albert Camus">
+                  <img src="./assets/img/camus-the-rebel.png" alt="Cover of The Rebel" />
+                  <span class="sr-only">The Rebel — Albert Camus</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/contemporaryphil04" target="_blank" rel="noopener" aria-label="After Virtue by Alasdair MacIntyre">
+                  <img src="./assets/img/macintyre-after-virtue.png" alt="Cover of After Virtue" />
+                  <span class="sr-only">After Virtue — Alasdair MacIntyre</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/contemporaryphil05" target="_blank" rel="noopener" aria-label="Truth and Method by Hans-Georg Gadamer">
+                  <img src="./assets/img/gadamer-truth-and-method.png" alt="Cover of Truth and Method" />
+                  <span class="sr-only">Truth and Method — Hans-Georg Gadamer</span>
+                </a>
+              </div>
+            </article>
+
+            <article class="reading-subgenre" id="contemporary-psychology" aria-labelledby="contemporary-psychology-title">
+              <h3 id="contemporary-psychology-title">Psychology</h3>
+              <div class="cover-grid" role="group" aria-labelledby="contemporary-psychology-title">
+                <a class="cover-card" href="https://amzn.to/contemporarypsych01" target="_blank" rel="noopener" aria-label="Man's Search for Meaning by Viktor E. Frankl">
+                  <img src="./assets/img/frankl-mans-search-for-meaning.png" alt="Cover of Man's Search for Meaning" />
+                  <span class="sr-only">Man's Search for Meaning — Viktor E. Frankl</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/contemporarypsych02" target="_blank" rel="noopener" aria-label="The Hero with a Thousand Faces by Joseph Campbell">
+                  <img src="./assets/img/campbell-hero-with-a-thousand-faces.png" alt="Cover of The Hero with a Thousand Faces" />
+                  <span class="sr-only">The Hero with a Thousand Faces — Joseph Campbell</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/contemporarypsych03" target="_blank" rel="noopener" aria-label="Maps of Meaning by Jordan B. Peterson">
+                  <img src="./assets/img/peterson-maps-of-meaning.png" alt="Cover of Maps of Meaning" />
+                  <span class="sr-only">Maps of Meaning — Jordan B. Peterson</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/contemporarypsych04" target="_blank" rel="noopener" aria-label="The Road Less Traveled by M. Scott Peck">
+                  <img src="./assets/img/peck-road-less-traveled.png" alt="Cover of The Road Less Traveled" />
+                  <span class="sr-only">The Road Less Traveled — M. Scott Peck</span>
+                </a>
+                <a class="cover-card" href="https://amzn.to/contemporarypsych05" target="_blank" rel="noopener" aria-label="Thinking, Fast and Slow by Daniel Kahneman">
+                  <img src="./assets/img/kahneman-thinking-fast-and-slow.png" alt="Cover of Thinking, Fast and Slow" />
+                  <span class="sr-only">Thinking, Fast and Slow — Daniel Kahneman</span>
+                </a>
+              </div>
+            </article>
+          </div>
+        </section>
       </section>
     </main>
 

--- a/style.css
+++ b/style.css
@@ -68,6 +68,17 @@ img {
   display: block;
 }
 
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
 h1,
 h2,
 h3,
@@ -561,55 +572,83 @@ a.nav__link::after {
   color: var(--muted);
 }
 
-.page--reading .reading-list {
-  display: grid;
-  gap: 2.4rem;
-  margin-top: 2.2rem;
+.page--reading .reading-catalog {
+  display: flex;
+  flex-direction: column;
+  gap: 3.4rem;
+  margin-top: 2.6rem;
 }
 
-@media (min-width: 980px) {
-  .page--reading .reading-list {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
+.page--reading .reading-era + .reading-era {
+  padding-top: 1.4rem;
+  border-top: 1px solid var(--surface-soft);
+}
+
+.era-heading {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.era-heading h2 {
+  margin: 0;
+}
+
+.subgenre-grid {
+  display: grid;
+  gap: 2.2rem;
+}
+
+@media (min-width: 960px) {
+  .subgenre-grid {
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
   }
 }
 
-.page--reading .reading-group {
-  background: var(--surface-alt);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
-  padding: 1.8rem;
-  box-shadow: var(--shadow-card);
-  display: flex;
-  flex-direction: column;
-  gap: 1.2rem;
+.reading-subgenre h3 {
+  margin: 0 0 0.85rem;
 }
 
-.page--reading .reading-group h2 {
-  margin: 0;
-}
-
-.reading-items {
-  list-style: none;
-  padding: 0;
-  margin: 0;
+.cover-grid {
   display: grid;
-  gap: 1.1rem;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 0;
+  border-radius: var(--radius-md);
+  background: var(--surface-soft);
+  border: 1px solid var(--border);
 }
 
-.reading-items li {
-  display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
+.cover-card {
+  position: relative;
+  display: block;
+  width: 100%;
+  aspect-ratio: 2 / 3;
+  overflow: hidden;
+  transition: transform 0.22s ease, box-shadow 0.22s ease;
 }
 
-.reading-title {
-  font-weight: 600;
-  color: var(--ink);
+.cover-card img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform 0.22s ease;
 }
 
-.reading-meta {
-  font-size: 0.95rem;
-  color: var(--subtle);
+.cover-card:hover,
+.cover-card:focus-visible {
+  transform: scale(1.05);
+  z-index: 2;
+  box-shadow: 0 16px 34px rgba(4, 6, 12, 0.55);
+}
+
+.cover-card:hover img,
+.cover-card:focus-visible img {
+  transform: scale(1.02);
+}
+
+.cover-card:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 4px;
 }
 
 .feature-grid {


### PR DESCRIPTION
## Summary
- replace the reading list content with an era- and genre-based table of roughly one hundred placeholder book covers
- ensure each cover links to a placeholder Amazon URL, includes hidden accessible labels, and groups works into the requested subgenres
- add styling for the cover grid so tiles share the same dimensions, stay flush with one another, and subtly expand on hover

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e36c2dcfec83308a0d234250b93213