### PR TITLE
Make featured book collapsible and convert mobile nav to a dropdown

### DIFF
--- a/about.html
+++ b/about.html
@@ -175,7 +175,7 @@
    </div>
  
    <script defer src="./js/data/data.js?v=20240607"></script>
-   <script defer src="./js/nav.js?v=20240607"></script>
+   <script defer src="./js/nav.js?v=20260326"></script>
    <script>
      window.addEventListener('DOMContentLoaded', () => {
        const links = (window.SITE_DATA && window.SITE_DATA.links) || window.LINKS || {};

--- a/books.html
+++ b/books.html
@@ -214,6 +214,6 @@
       }
     });
   </script>
-  <script defer src="./js/nav.js?v=20240607"></script>
+  <script defer src="./js/nav.js?v=20260326"></script>
 </body>
 </html>

--- a/contact.html
+++ b/contact.html
@@ -65,7 +65,7 @@
   </div>
 
   <script defer src="./js/data/data.js?v=20240607"></script>
-  <script defer src="./js/nav.js?v=20240607"></script>
+  <script defer src="./js/nav.js?v=20260326"></script>
   <script>
     window.addEventListener('DOMContentLoaded', () => {
       const LINKS = (window.SITE_DATA && window.SITE_DATA.links) || window.LINKS || {};

--- a/index.html
+++ b/index.html
@@ -138,7 +138,7 @@
 
   <script defer src="./js/data/data.js?v=20240607"></script>
   <script defer src="./js/projects-module.js?v=20240607"></script>
-  <script defer src="./js/nav.js?v=20240607"></script>
+  <script defer src="./js/nav.js?v=20260326"></script>
   <script>
     window.addEventListener('DOMContentLoaded', () => {
       // footer year

--- a/js/nav.js
+++ b/js/nav.js
@@ -40,4 +40,66 @@
   } catch (err) {
     // no-op if location parsing fails
   }
+
+  (function initMobileNavDropdown() {
+    const header = document.querySelector('.site-header');
+    const nav = header && header.querySelector('.nav');
+    if (!header || !nav) return;
+
+    const toggle = document.createElement('button');
+    toggle.className = 'nav-toggle';
+    toggle.type = 'button';
+    toggle.setAttribute('aria-expanded', 'false');
+    toggle.setAttribute('aria-controls', 'primary-nav');
+    toggle.innerHTML = '<span class="nav-toggle__icon" aria-hidden="true">☰</span><span>Menu</span>';
+
+    if (!nav.id) nav.id = 'primary-nav';
+    header.insertBefore(toggle, nav);
+
+    const closeMenu = () => {
+      header.classList.remove('nav-open');
+      toggle.setAttribute('aria-expanded', 'false');
+    };
+
+    toggle.addEventListener('click', () => {
+      const isOpen = header.classList.toggle('nav-open');
+      toggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+    });
+
+    nav.querySelectorAll('.nav__link').forEach((link) => {
+      link.addEventListener('click', closeMenu);
+    });
+
+    document.addEventListener('click', (event) => {
+      if (!header.classList.contains('nav-open')) return;
+      if (header.contains(event.target)) return;
+      closeMenu();
+    });
+  })();
+
+  (function initFeaturedBookCollapse() {
+    const bookCopy = document.querySelector('.book-copy');
+    if (!bookCopy) return;
+
+    const description = bookCopy.querySelector('p');
+    const actionRow = bookCopy.querySelector('.cta-row');
+    if (!description || !actionRow) return;
+
+    bookCopy.classList.add('is-collapsed');
+
+    const toggle = document.createElement('button');
+    toggle.type = 'button';
+    toggle.className = 'btn ghost book-copy__toggle';
+    toggle.setAttribute('aria-expanded', 'false');
+    toggle.textContent = 'Read summary';
+
+    actionRow.insertAdjacentElement('beforebegin', toggle);
+
+    toggle.addEventListener('click', () => {
+      const isCollapsed = bookCopy.classList.toggle('is-collapsed');
+      const isExpanded = !isCollapsed;
+      toggle.textContent = isExpanded ? 'Hide summary' : 'Read summary';
+      toggle.setAttribute('aria-expanded', isExpanded ? 'true' : 'false');
+    });
+  })();
 })();

--- a/projects.html
+++ b/projects.html
@@ -69,7 +69,7 @@
 
   <script defer src="./js/data/data.js?v=20240607"></script>
   <script defer src="./js/projects-module.js?v=20240607"></script>
-  <script defer src="./js/nav.js?v=20240607"></script>
+  <script defer src="./js/nav.js?v=20260326"></script>
   <script defer src="./js/projects.js?v=20240607"></script>
 </body>
 </html>

--- a/reading-list.html
+++ b/reading-list.html
@@ -1106,7 +1106,7 @@
   </div>
 
   <script defer src="./js/data/data.js?v=20240607"></script>
-  <script defer src="./js/nav.js?v=20240607"></script>
+  <script defer src="./js/nav.js?v=20260326"></script>
   <script>
     document.addEventListener('DOMContentLoaded', () => {
       const year = document.getElementById('year');

--- a/style.css
+++ b/style.css
@@ -286,6 +286,28 @@ padding: var(--space-3) var(--space-4);
   gap: 0.85rem;
 }
 
+.nav-toggle {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  width: fit-content;
+  padding: 0.45rem 0.75rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--plum);
+  background: rgba(19, 24, 44, 0.92);
+  color: var(--ink);
+  font-weight: 600;
+  font-size: 0.95rem;
+  cursor: pointer;
+}
+
+.nav-toggle__icon {
+  display: inline-block;
+  font-size: 1rem;
+  line-height: 1;
+}
+
 .nav__link {
   padding: 0.35rem 0.75rem;
   border-radius: var(--radius-sm);
@@ -307,12 +329,43 @@ transition: color var(--motion-fast), border-color var(--motion-fast);
 
 @media (max-width: 720px) {
   .site-header {
-    flex-direction: column;
-    align-items: stretch;
+    position: relative;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .nav-toggle {
+    display: inline-flex;
   }
 
   .nav {
-    justify-content: center;
+    position: absolute;
+    right: var(--space-3);
+    top: calc(100% - 0.1rem);
+    z-index: 30;
+    width: min(260px, calc(100vw - 2rem));
+    flex-direction: column;
+    gap: 0.3rem;
+    padding: 0.5rem;
+    border-radius: var(--radius-md);
+    border: 1px solid var(--border);
+    background: rgba(8, 12, 22, 0.98);
+    box-shadow: 0 14px 28px rgba(4, 6, 12, 0.45);
+    opacity: 0;
+    pointer-events: none;
+    transform: translateY(-6px);
+    transition: opacity var(--motion-fast), transform var(--motion-fast);
+  }
+
+  .site-header.nav-open .nav {
+    opacity: 1;
+    pointer-events: auto;
+    transform: translateY(0);
+  }
+
+  .nav__link {
+    width: 100%;
   }
 }
 
@@ -789,6 +842,18 @@ gap: calc(var(--space-6) + 1rem);
 .book-copy .book-desc p {
   margin-bottom: 0.85rem;
   color: var(--muted);
+}
+
+.book-copy p {
+  margin-bottom: 0;
+}
+
+.book-copy.is-collapsed p {
+  display: none;
+}
+
+.book-copy__toggle {
+  width: fit-content;
 }
 
 .flip {


### PR DESCRIPTION
### Motivation
- Reduce the vertical space used by the long featured-publication summary on the home page and provide a compact mobile-friendly navigation pattern.
- Replace the floating mobile nav with an explicit dropdown menu to improve usability on small screens.

### Description
- Add mobile nav toggle UI and styles in `style.css` (`.nav-toggle`, responsive dropdown panel, and `.site-header.nav-open` state) and make small layout adjustments for the header at `<=720px`.
- Implement `initMobileNavDropdown()` in `js/nav.js` to inject a Menu button, manage `aria-expanded`, toggle the `.nav-open` state, close on link click, and close on outside clicks.
- Implement `initFeaturedBookCollapse()` in `js/nav.js` to default the `.book-copy` area to collapsed, insert a `Read summary` / `Hide summary` toggle button, and toggle the collapsed state via `.book-copy.is-collapsed` CSS rules added to `style.css`.
- Bump the `nav.js` cache-busting query string in `index.html`, `about.html`, `books.html`, `contact.html`, `projects.html`, and `reading-list.html` so browsers load the updated script.

### Testing
- Ran `node --check js/nav.js` to validate the updated script and it completed without errors.
- Ran `git diff --check` to ensure no trailing-diff issues and it reported no problems.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c568a7bfa48330abeaf53533841670)