### PR TITLE
Drop Omega Point subtitle, add Harmony Academy role, restyle hero

### DIFF
--- a/books.html
+++ b/books.html
@@ -96,14 +96,14 @@
                 <span class="status status--contract">Under contract</span>
                 <span class="meta meta--caps">Monograph</span>
               </div>
-              <h3>Philip K. Dick's Omega Point: Pierre Teilhard de Chardin's Eschatology Reimagined</h3>
+              <h3>Philip K. Dick's Omega Point</h3>
               <p class="org">Anti-Oedipus Press · Exegetics: PKD Studies</p>
               <div class="desc">
                 <p>This monograph examines Philip K. Dick's engagement with Pierre Teilhard de Chardin's theology — particularly the concept of the Omega Point — drawing primarily from Dick's <em>Exegesis</em>. While Dick references Chardin and the Omega Point several times, the connection remains underexplored in Dickian scholarship. The volume maps the extent of Dick's reading of Chardin and investigates how he makes use of and expands Chardin's eschatological framework.</p>
               </div>
               <div class="citation">
-                <p>Barros, M. C. (forthcoming). <em>Philip K. Dick's Omega Point: Pierre Teilhard de Chardin's eschatology reimagined</em>. Anti-Oedipus Press.</p>
-                <button class="copy-btn" type="button" data-copy="Barros, M. C. (forthcoming). Philip K. Dick's Omega Point: Pierre Teilhard de Chardin's eschatology reimagined. Anti-Oedipus Press.">Copy citation</button>
+                <p>Barros, M. C. (forthcoming). <em>Philip K. Dick's Omega Point</em>. Anti-Oedipus Press.</p>
+                <button class="copy-btn" type="button" data-copy="Barros, M. C. (forthcoming). Philip K. Dick's Omega Point. Anti-Oedipus Press.">Copy citation</button>
               </div>
             </div>
           </article>

--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@
     <section class="hero" aria-labelledby="home-title">
       <div class="wrap">
         <span class="eyebrow">PhD Candidate · National University</span>
-        <h1 id="home-title">Religious experience, <span class="accent">thought</span>, and expression.</h1>
+        <h1 id="home-title">Religious experience, thought, <span class="accent">&amp;</span> expression.</h1>
         <p class="lede">I study religious experience as lived practice, cultural form, and cognitive phenomenon.</p>
         <div class="cta-row">
           <a class="btn" href="./projects.html">Explore the work</a>

--- a/style.css
+++ b/style.css
@@ -856,6 +856,7 @@ main { display: block; }
 
 .tl-dot--professional { background: #a8742a; }
 .tl-dot--teaching { background: #3e6f52; }
+.tl-dot--research { background: #2c7a7b; }
 .tl-dot--military { background: #44618c; }
 .tl-dot--publishing { background: #6d4a86; }
 
@@ -917,6 +918,7 @@ main { display: block; }
 
 .tl-bar--professional { background: #a8742a; color: #a8742a; }
 .tl-bar--teaching { background: #3e6f52; color: #3e6f52; }
+.tl-bar--research { background: #2c7a7b; color: #2c7a7b; }
 .tl-bar--military { background: #44618c; color: #44618c; }
 .tl-bar--publishing { background: #6d4a86; color: #6d4a86; }
 

--- a/timeline.html
+++ b/timeline.html
@@ -102,7 +102,7 @@
         bullets: ['Event coordination', 'Operations management'] },
       { id: 2, title: 'Acquisitions & Developmental Editor', org: 'Eclogue Press', location: '', start: 2025.6, end: null, track: 'Publishing',
         bullets: ['Acquisitions and developmental editing in the fantasy and sci-fi fiction genre'] },
-      { id: 3, title: 'Owner / Operations Consultant', org: 'Barros Consulting', location: 'Alexandria, VA (remote)', start: 2024.6, end: null, track: 'Professional',
+      { id: 3, title: 'Owner / Operations Consultant', org: 'Barros Consulting', location: 'Alexandria, VA (remote)', start: 2024.6, end: 2026.1, track: 'Professional',
         bullets: [
           'Lean/Six Sigma-based consulting for service businesses',
           'Fractional COO for 541 Junk Removal and 541 Hardscaping',

--- a/timeline.html
+++ b/timeline.html
@@ -34,7 +34,7 @@
       <div class="wrap">
         <span class="eyebrow">Career</span>
         <h1 id="tl-title">Work history</h1>
-        <p class="lede">Concurrent tracks across scholarship, teaching, publishing, and operations. Select any bar for details.</p>
+        <p class="lede">Concurrent tracks across scholarship, teaching, research, publishing, and operations. Select any bar for details.</p>
       </div>
     </section>
 
@@ -44,6 +44,7 @@
         <div class="tl-legend" aria-hidden="true">
           <span><i class="tl-dot tl-dot--professional"></i>Professional</span>
           <span><i class="tl-dot tl-dot--teaching"></i>Teaching</span>
+          <span><i class="tl-dot tl-dot--research"></i>Research</span>
           <span><i class="tl-dot tl-dot--military"></i>Military</span>
           <span><i class="tl-dot tl-dot--publishing"></i>Publishing</span>
         </div>
@@ -67,6 +68,7 @@
             <li>Barros Consulting — Owner / Operations Consultant (2024–present)</li>
             <li>Eclogue Press — Acquisitions &amp; Developmental Editor (2025–present)</li>
             <li>OYD Live — Director of Business Affairs (2025–present)</li>
+            <li>Harmony Academy (Sanford Learning Lab, National University) — Research Assistant (2026–present)</li>
           </ol>
         </noscript>
 
@@ -94,6 +96,8 @@
   document.addEventListener('DOMContentLoaded', () => {
     // end: null = present
     const JOBS = [
+      { id: 11, title: 'Research Assistant', org: 'Harmony Academy · Sanford Learning Lab, National University', location: '', start: 2026.35, end: null, track: 'Research',
+        bullets: ['Research assistant at Harmony Academy, part of the Sanford Learning Lab at National University'] },
       { id: 1, title: 'Director of Business Affairs', org: 'OYD Live', location: 'Largo, FL', start: 2025.9, end: null, track: 'Professional',
         bullets: ['Event coordination', 'Operations management'] },
       { id: 2, title: 'Acquisitions & Developmental Editor', org: 'Eclogue Press', location: '', start: 2025.6, end: null, track: 'Publishing',


### PR DESCRIPTION
## Summary
- Removed the "Pierre Teilhard de Chardin's Eschatology Reimagined" subtitle from *Philip K. Dick's Omega Point* on the Books page — both the display heading and the formatted citation now read just "Philip K. Dick's Omega Point"
- Added a new Timeline entry: Research Assistant at Harmony Academy (Sanford Learning Lab, National University), started ~May 2026, present. Introduced a new teal "Research" track (legend + bar/dot colors) since the role is neither classroom Teaching nor general Professional ops work
- Restyled the homepage hero: removed the italic/colored emphasis on "thought" (which read as arbitrary conceptual emphasis) and instead styled the ampersand in "thought, & expression" — a typographic flourish rather than a semantic one

## Test plan
- [x] Verified the Omega Point title/citation render without the subtitle on the Books page
- [x] Verified the new Harmony Academy entry appears correctly positioned on the desktop Gantt chart and mobile list, with a working detail panel and legend entry
- [x] Verified the restyled hero renders correctly on desktop


---
_Generated by [Claude Code](https://claude.ai/code/session_01GUktHxoTAZPx2oYJAo93oC)_