### PR TITLE
Remove all blog/Substack references — Mythonoesis is shut down

### DIFF
--- a/about.html
+++ b/about.html
@@ -42,7 +42,6 @@
         <a href="./projects.html">Projects</a>
         <a href="./timeline.html">Timeline</a>
         <a href="./reading-list.html">Reading List</a>
-        <a href="https://mythonoesis.substack.com/" target="_blank" rel="noopener">Blog<span class="ext">↗</span></a>
         <a href="./contact.html">Contact</a>
       </nav>
     </div>
@@ -60,7 +59,6 @@
             <p style="margin-top:0.6rem">My work integrates research, teaching, and applied systems experience across academic and non-academic settings.</p>
             <div class="cta-row" style="margin-top:1.8rem">
               <a class="btn btn--small" href="./books.html">Books</a>
-              <a class="btn btn--small btn--ghost" href="https://mythonoesis.substack.com/" target="_blank" rel="noopener">Blog</a>
               <a class="btn btn--small btn--ghost" href="https://orcid.org/0000-0001-5462-8926" target="_blank" rel="noopener">ORCID</a>
               <a class="btn btn--small btn--ghost" href="https://www.linkedin.com/in/michaelbarros22" target="_blank" rel="noopener">LinkedIn</a>
             </div>
@@ -222,9 +220,8 @@
   <footer class="site-footer">
     <div class="wrap">
       <p class="name">Michael C. Barros</p>
-      <p class="tag">Essays · Research · Projects</p>
+      <p class="tag">Research · Books · Projects</p>
       <nav class="footer-links" aria-label="Profiles">
-        <a href="https://mythonoesis.substack.com/" target="_blank" rel="noopener">Substack</a>
         <a href="https://orcid.org/0000-0001-5462-8926" target="_blank" rel="noopener">ORCID</a>
         <a href="https://national.academia.edu/MichaelBarros" target="_blank" rel="noopener">Academia.edu</a>
         <a href="https://www.linkedin.com/in/michaelbarros22" target="_blank" rel="noopener">LinkedIn</a>

--- a/books.html
+++ b/books.html
@@ -22,7 +22,6 @@
         <a href="./projects.html">Projects</a>
         <a href="./timeline.html">Timeline</a>
         <a href="./reading-list.html">Reading List</a>
-        <a href="https://mythonoesis.substack.com/" target="_blank" rel="noopener">Blog<span class="ext">↗</span></a>
         <a href="./contact.html">Contact</a>
       </nav>
     </div>
@@ -117,9 +116,8 @@
   <footer class="site-footer">
     <div class="wrap">
       <p class="name">Michael C. Barros</p>
-      <p class="tag">Essays · Research · Projects</p>
+      <p class="tag">Research · Books · Projects</p>
       <nav class="footer-links" aria-label="Profiles">
-        <a href="https://mythonoesis.substack.com/" target="_blank" rel="noopener">Substack</a>
         <a href="https://orcid.org/0000-0001-5462-8926" target="_blank" rel="noopener">ORCID</a>
         <a href="https://national.academia.edu/MichaelBarros" target="_blank" rel="noopener">Academia.edu</a>
         <a href="https://www.linkedin.com/in/michaelbarros22" target="_blank" rel="noopener">LinkedIn</a>

--- a/contact.html
+++ b/contact.html
@@ -22,7 +22,6 @@
         <a href="./projects.html">Projects</a>
         <a href="./timeline.html">Timeline</a>
         <a href="./reading-list.html">Reading List</a>
-        <a href="https://mythonoesis.substack.com/" target="_blank" rel="noopener">Blog<span class="ext">↗</span></a>
         <a href="./contact.html" aria-current="page">Contact</a>
       </nav>
     </div>
@@ -53,10 +52,6 @@
           <span class="meta meta--caps" style="display:block; margin-bottom:0.9rem">Elsewhere</span>
           <ul class="row-list">
             <li>
-              <span class="primary">Mythonoesis</span>
-              <a class="year" href="https://mythonoesis.substack.com/" target="_blank" rel="noopener">Substack ↗</a>
-            </li>
-            <li>
               <span class="primary">ORCID</span>
               <a class="year" href="https://orcid.org/0000-0001-5462-8926" target="_blank" rel="noopener">0000-0001-5462-8926 ↗</a>
             </li>
@@ -78,9 +73,8 @@
   <footer class="site-footer">
     <div class="wrap">
       <p class="name">Michael C. Barros</p>
-      <p class="tag">Essays · Research · Projects</p>
+      <p class="tag">Research · Books · Projects</p>
       <nav class="footer-links" aria-label="Profiles">
-        <a href="https://mythonoesis.substack.com/" target="_blank" rel="noopener">Substack</a>
         <a href="https://orcid.org/0000-0001-5462-8926" target="_blank" rel="noopener">ORCID</a>
         <a href="https://national.academia.edu/MichaelBarros" target="_blank" rel="noopener">Academia.edu</a>
         <a href="https://www.linkedin.com/in/michaelbarros22" target="_blank" rel="noopener">LinkedIn</a>

--- a/index.html
+++ b/index.html
@@ -26,7 +26,6 @@
         <a href="./projects.html">Projects</a>
         <a href="./timeline.html">Timeline</a>
         <a href="./reading-list.html">Reading List</a>
-        <a href="https://mythonoesis.substack.com/" target="_blank" rel="noopener">Blog<span class="ext">↗</span></a>
         <a href="./contact.html">Contact</a>
       </nav>
     </div>
@@ -42,7 +41,7 @@
         <p class="lede">I study religious experience as lived practice, cultural form, and cognitive phenomenon.</p>
         <div class="cta-row">
           <a class="btn" href="./projects.html">Explore the work</a>
-          <a class="arrow-link" href="https://mythonoesis.substack.com/" target="_blank" rel="noopener">Read the blog</a>
+          <a class="arrow-link" href="./books.html">Browse publications</a>
         </div>
         <div class="tags" aria-label="Areas of focus">
           <span>Media &amp; Religion</span>
@@ -152,28 +151,13 @@
       </div>
     </section>
 
-    <!-- Writing -->
-    <section class="section section--band" aria-labelledby="writing-title">
-      <div class="wrap">
-        <div class="reveal">
-          <span class="eyebrow">Writing</span>
-          <h2 id="writing-title">Mythonoesis</h2>
-          <p class="lede">Essays on myth, media, and religious imagination — where meaning surfaces in games, film, and fiction.</p>
-          <div class="cta-row" style="margin-top:1.6rem">
-            <a class="btn btn--ghost" href="https://mythonoesis.substack.com/" target="_blank" rel="noopener">Read on Substack</a>
-          </div>
-        </div>
-      </div>
-    </section>
-
   </main>
 
   <footer class="site-footer">
     <div class="wrap">
       <p class="name">Michael C. Barros</p>
-      <p class="tag">Essays · Research · Projects</p>
+      <p class="tag">Research · Books · Projects</p>
       <nav class="footer-links" aria-label="Profiles">
-        <a href="https://mythonoesis.substack.com/" target="_blank" rel="noopener">Substack</a>
         <a href="https://orcid.org/0000-0001-5462-8926" target="_blank" rel="noopener">ORCID</a>
         <a href="https://national.academia.edu/MichaelBarros" target="_blank" rel="noopener">Academia.edu</a>
         <a href="https://www.linkedin.com/in/michaelbarros22" target="_blank" rel="noopener">LinkedIn</a>

--- a/index.html
+++ b/index.html
@@ -151,6 +151,36 @@
       </div>
     </section>
 
+    <!-- Appearances -->
+    <section class="section section--band" aria-labelledby="appearances-title">
+      <div class="wrap">
+        <div class="section-head reveal">
+          <div>
+            <span class="eyebrow">Media</span>
+            <h2 id="appearances-title" style="margin:0">Appearances</h2>
+          </div>
+        </div>
+        <div class="appearance-grid reveal">
+          <a class="appearance-card" href="https://www.youtube.com/watch?v=4o5QXWKq0BU" target="_blank" rel="noopener">
+            <div class="appearance-card__meta">
+              <span class="channel">DickHeads Podcast</span>
+              <span class="date">June 14, 2026</span>
+            </div>
+            <h3>Zoom Hangout Interview #16 — Michael Barros on The Esoteric Theology of Philip K. Dick</h3>
+            <span class="arrow-link">Watch on YouTube</span>
+          </a>
+          <a class="appearance-card" href="https://www.youtube.com/watch?v=1wBZYqJPuk0" target="_blank" rel="noopener">
+            <div class="appearance-card__meta">
+              <span class="channel">Patrick Abbott</span>
+              <span class="date">May 1, 2026</span>
+            </div>
+            <h3>Michael C. Barros: Interview on Religion in Fiction</h3>
+            <span class="arrow-link">Watch on YouTube</span>
+          </a>
+        </div>
+      </div>
+    </section>
+
   </main>
 
   <footer class="site-footer">

--- a/projects.html
+++ b/projects.html
@@ -22,7 +22,6 @@
         <a href="./projects.html" aria-current="page">Projects</a>
         <a href="./timeline.html">Timeline</a>
         <a href="./reading-list.html">Reading List</a>
-        <a href="https://mythonoesis.substack.com/" target="_blank" rel="noopener">Blog<span class="ext">↗</span></a>
         <a href="./contact.html">Contact</a>
       </nav>
     </div>
@@ -118,9 +117,8 @@
   <footer class="site-footer">
     <div class="wrap">
       <p class="name">Michael C. Barros</p>
-      <p class="tag">Essays · Research · Projects</p>
+      <p class="tag">Research · Books · Projects</p>
       <nav class="footer-links" aria-label="Profiles">
-        <a href="https://mythonoesis.substack.com/" target="_blank" rel="noopener">Substack</a>
         <a href="https://orcid.org/0000-0001-5462-8926" target="_blank" rel="noopener">ORCID</a>
         <a href="https://national.academia.edu/MichaelBarros" target="_blank" rel="noopener">Academia.edu</a>
         <a href="https://www.linkedin.com/in/michaelbarros22" target="_blank" rel="noopener">LinkedIn</a>

--- a/reading-list.html
+++ b/reading-list.html
@@ -22,7 +22,6 @@
         <a href="./projects.html">Projects</a>
         <a href="./timeline.html">Timeline</a>
         <a href="./reading-list.html" aria-current="page">Reading List</a>
-        <a href="https://mythonoesis.substack.com/" target="_blank" rel="noopener">Blog<span class="ext">↗</span></a>
         <a href="./contact.html">Contact</a>
       </nav>
     </div>
@@ -1103,9 +1102,8 @@
   <footer class="site-footer">
     <div class="wrap">
       <p class="name">Michael C. Barros</p>
-      <p class="tag">Essays · Research · Projects</p>
+      <p class="tag">Research · Books · Projects</p>
       <nav class="footer-links" aria-label="Profiles">
-        <a href="https://mythonoesis.substack.com/" target="_blank" rel="noopener">Substack</a>
         <a href="https://orcid.org/0000-0001-5462-8926" target="_blank" rel="noopener">ORCID</a>
         <a href="https://national.academia.edu/MichaelBarros" target="_blank" rel="noopener">Academia.edu</a>
         <a href="https://www.linkedin.com/in/michaelbarros22" target="_blank" rel="noopener">LinkedIn</a>

--- a/style.css
+++ b/style.css
@@ -598,6 +598,72 @@ main { display: block; }
   color: var(--accent);
 }
 
+/* ---------- Appearances ---------- */
+
+.appearance-grid {
+  display: grid;
+  gap: 1.25rem;
+}
+
+@media (min-width: 700px) {
+  .appearance-grid { grid-template-columns: 1fr 1fr; }
+}
+
+.appearance-card {
+  display: block;
+  padding: 1.7rem 1.9rem;
+  background: var(--card);
+  border: 1px solid var(--rule);
+  border-radius: 10px;
+  color: inherit;
+  box-shadow: 0 1px 2px rgba(33, 29, 22, 0.03);
+  transition: border-color 180ms var(--ease), box-shadow 180ms var(--ease), transform 180ms var(--ease);
+}
+
+.appearance-card:hover {
+  text-decoration: none;
+  border-color: var(--rule-strong);
+  box-shadow: 0 14px 30px -16px rgba(33, 29, 22, 0.26);
+  transform: translateY(-2px);
+}
+
+.appearance-card__meta {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 0.7rem;
+}
+
+.appearance-card .channel {
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+
+.appearance-card .date {
+  font-size: 0.8rem;
+  color: var(--ink-faint);
+  white-space: nowrap;
+}
+
+.appearance-card h3 {
+  margin: 0;
+  font-size: 1.2rem;
+  line-height: 1.3;
+  color: var(--ink);
+}
+
+.appearance-card:hover h3 { color: var(--accent-deep); }
+
+.appearance-card .arrow-link {
+  display: inline-block;
+  margin-top: 1rem;
+  font-size: 0.85rem;
+}
+
 /* ---------- Now / status list ---------- */
 
 .now-list {

--- a/timeline.html
+++ b/timeline.html
@@ -22,7 +22,6 @@
         <a href="./projects.html">Projects</a>
         <a href="./timeline.html" aria-current="page">Timeline</a>
         <a href="./reading-list.html">Reading List</a>
-        <a href="https://mythonoesis.substack.com/" target="_blank" rel="noopener">Blog<span class="ext">↗</span></a>
         <a href="./contact.html">Contact</a>
       </nav>
     </div>
@@ -80,9 +79,8 @@
   <footer class="site-footer">
     <div class="wrap">
       <p class="name">Michael C. Barros</p>
-      <p class="tag">Essays · Research · Projects</p>
+      <p class="tag">Research · Books · Projects</p>
       <nav class="footer-links" aria-label="Profiles">
-        <a href="https://mythonoesis.substack.com/" target="_blank" rel="noopener">Substack</a>
         <a href="https://orcid.org/0000-0001-5462-8926" target="_blank" rel="noopener">ORCID</a>
         <a href="https://national.academia.edu/MichaelBarros" target="_blank" rel="noopener">Academia.edu</a>
         <a href="https://www.linkedin.com/in/michaelbarros22" target="_blank" rel="noopener">LinkedIn</a>


### PR DESCRIPTION
## Summary
- Removed the "Blog" nav link and footer "Substack" link from every page
- Removed the homepage "Writing" section (Mythonoesis blurb + "Read on Substack" CTA) and the hero's "Read the blog" link, replacing it with a link to the Books page
- Removed the About page's "Blog" button
- Removed the "Mythonoesis" entry from the Contact page's Elsewhere list
- Updated the footer tagline from "Essays · Research · Projects" to "Research · Books · Projects" so it matches what's actually on the site now that the blog is gone

## Test plan
- [x] Grepped the whole repo for `mythonoesis`, `substack`, and stray "Blog" links — none remain
- [x] Screenshotted the homepage, Contact, and About pages locally to confirm layout holds up cleanly with the sections removed


---
_Generated by [Claude Code](https://claude.ai/code/session_01GUktHxoTAZPx2oYJAo93oC)_