### PR TITLE
Remove redundant hero subtext on homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,7 +38,6 @@
       <div class="wrap">
         <span class="eyebrow">PhD Candidate · National University</span>
         <h1 id="home-title">Religious experience, thought, <span class="accent">&amp;</span> expression.</h1>
-        <p class="lede">I study religious experience as lived practice, cultural form, and cognitive phenomenon.</p>
         <div class="cta-row">
           <a class="btn" href="./projects.html">Explore the work</a>
           <a class="arrow-link" href="./books.html">Browse publications</a>

--- a/style.css
+++ b/style.css
@@ -494,7 +494,7 @@ main { display: block; }
 
 .hero h1 {
   max-width: 21ch;
-  margin-bottom: 0.4em;
+  margin-bottom: 0.9em;
 }
 
 .hero h1 .accent {
@@ -502,8 +502,6 @@ main { display: block; }
   color: var(--accent);
   font-weight: 380;
 }
-
-.hero .lede { margin-bottom: 2.2rem; }
 
 .hero .tags { margin-top: 2.6rem; }
 


### PR DESCRIPTION
## Summary
- Removed the "I study religious experience as lived practice, cultural form, and cognitive phenomenon." paragraph under the homepage hero heading — it just restated the headline above it in different words
- Rebalanced hero spacing now that the paragraph is gone (increased heading bottom margin so the CTA buttons don't sit too close)
- Removed the now-unused `.hero .lede` CSS rule

## Test plan
- [x] Screenshotted the hero on desktop and mobile to confirm spacing reads cleanly without the paragraph


---
_Generated by [Claude Code](https://claude.ai/code/session_01GUktHxoTAZPx2oYJAo93oC)_