### PR TITLE
Add Harmony Academy to Current Roles on About page

### DIFF
--- a/about.html
+++ b/about.html
@@ -85,6 +85,10 @@
             <span class="detail">PhD candidate studying dreams, religion, and cognition at National University.</span>
           </li>
           <li>
+            <span class="primary">Analyst</span>
+            <span class="detail">Primarily quantitative analysis as a research assistant at Harmony Academy, part of the Sanford Learning Lab at National University.</span>
+          </li>
+          <li>
             <span class="primary">Instructor</span>
             <span class="detail">Adjunct philosophy instructor at University of the People; instructor at Waypoint Institute.</span>
           </li>


### PR DESCRIPTION
## Summary
- Added a new "Analyst" entry to the "Current roles" list on the About page, noting that the primary work at Harmony Academy (part of the Sanford Learning Lab at National University) is quantitative analysis as a research assistant — matching the role already on the Timeline page

(Re-opened: the previous PR #45 for this same change was accidentally closed/deleted before merging.)

## Test plan
- [x] Screenshotted the "Current roles" card list to confirm the new entry renders correctly alongside the existing five


---
_Generated by [Claude Code](https://claude.ai/code/session_01GUktHxoTAZPx2oYJAo93oC)_