### PR TITLE
Fix inconsistent date placement in Education/Certifications rows

### DIFF
--- a/about.html
+++ b/about.html
@@ -133,35 +133,35 @@
         </div>
         <ul class="row-list reveal">
           <li>
-            <span>
+            <span class="entry">
               <span class="primary">PhD in Psychology</span>
               <span class="secondary">National University · Dissertation: Sensorimotor Content in Dreams and Waking Religious Cognition</span>
             </span>
             <span class="year">ABD — in progress</span>
           </li>
           <li>
-            <span>
+            <span class="entry">
               <span class="primary">MA in Biblical &amp; Theological Studies</span>
               <span class="secondary">Trevecca Nazarene University</span>
             </span>
             <span class="year">2021</span>
           </li>
           <li>
-            <span>
+            <span class="entry">
               <span class="primary">BA in Mathematics</span>
               <span class="secondary">Southern New Hampshire University · Applied Mathematics</span>
             </span>
             <span class="year">2018</span>
           </li>
           <li>
-            <span>
+            <span class="entry">
               <span class="primary">BS in Electronics Engineering Technology</span>
               <span class="secondary">ECPI University</span>
             </span>
             <span class="year">2015</span>
           </li>
           <li>
-            <span>
+            <span class="entry">
               <span class="primary">AAS in Air &amp; Space Operations Technology</span>
               <span class="secondary">Community College of the Air Force</span>
             </span>
@@ -181,35 +181,35 @@
         </div>
         <ul class="row-list reveal">
           <li>
-            <span>
+            <span class="entry">
               <span class="primary">Six Sigma Black Belt</span>
               <span class="secondary">The Council for Six Sigma Certification</span>
             </span>
             <span class="year">2025</span>
           </li>
           <li>
-            <span>
+            <span class="entry">
               <span class="primary">Researchers — Social and Behavioral Focus</span>
               <span class="secondary">CITI Program</span>
             </span>
             <span class="year">2025</span>
           </li>
           <li>
-            <span>
+            <span class="entry">
               <span class="primary">Basic Instructor Course (BIC)</span>
               <span class="secondary">U.S. Air Force</span>
             </span>
             <span class="year">2014</span>
           </li>
           <li>
-            <span>
+            <span class="entry">
               <span class="primary">Advanced Evangelical Ethos of Bishop Barron</span>
               <span class="secondary">Word on Fire Institute · currently enrolled</span>
             </span>
             <span class="year">In progress</span>
           </li>
           <li>
-            <span>
+            <span class="entry">
               <span class="primary">Certificate in Evangelization: The Evangelical Ethos of Bishop Barron</span>
               <span class="secondary">Word on Fire Institute</span>
             </span>

--- a/style.css
+++ b/style.css
@@ -735,6 +735,13 @@ main { display: block; }
   font-weight: 400;
 }
 
+/* Force the date onto its own line below ~840px so short entries (e.g. a
+   brief degree title) don't sit inline while longer siblings wrap — keeps
+   every row's date in the same position regardless of content length. */
+@media (max-width: 840px) {
+  .row-list .entry { width: 100%; }
+}
+
 .row-list .year {
   font-size: 0.82rem;
   color: var(--accent);


### PR DESCRIPTION
## Summary
- Fixed a flexbox line-wrapping bug on the About page's Education and Certifications lists: each row's date sat inline next to the title when the row's combined text happened to be short enough to fit on one line, but wrapped onto its own line below when the text was longer. At ~390-430px viewport widths this meant the MA degree's date rendered inline next to its title while every other degree's date sat below it — visually inconsistent.
- Wrapped the title+school block in a `.entry` span and forced it to full width below 840px, so the date always falls on its own line the same way for every row, regardless of how long that row's text happens to be. Desktop (date inline, right-aligned) is unchanged.

## Test plan
- [x] Reproduced the original bug at 428px width (matches the reporter's device) — confirmed only the MA row rendered differently before the fix
- [x] Verified all Education and Certifications rows now render the date consistently at 390px, 428px, and 700px
- [x] Verified desktop layout (1280px) is unchanged


---
_Generated by [Claude Code](https://claude.ai/code/session_01GUktHxoTAZPx2oYJAo93oC)_