### PR TITLE
Label hero research areas, rename CTAs, tidy roles & continuing ed

### DIFF
--- a/about.html
+++ b/about.html
@@ -89,8 +89,8 @@
             <span class="detail">Primarily quantitative analysis as a research assistant at Harmony Academy, part of the Sanford Learning Lab at National University.</span>
           </li>
           <li>
-            <span class="primary">Instructor</span>
-            <span class="detail">Adjunct philosophy instructor at University of the People; instructor at Waypoint Institute.</span>
+            <span class="primary">Educator</span>
+            <span class="detail">Adjunct philosophy instructor at University of the People; instructor at Waypoint Institute; discussion group leader at Word on Fire Institute.</span>
           </li>
           <li>
             <span class="primary">Editor</span>
@@ -99,10 +99,6 @@
           <li>
             <span class="primary">Operator</span>
             <span class="detail">Director of Business Affairs at OYD Live.</span>
-          </li>
-          <li>
-            <span class="primary">Discussion Group Lead</span>
-            <span class="detail">Certificate in Evangelization: The Evangelical Ethos of Bishop Barron · Word on Fire Institute.</span>
           </li>
         </ul>
       </div>
@@ -204,9 +200,16 @@
           <li>
             <span class="entry">
               <span class="primary">Advanced Evangelical Ethos of Bishop Barron</span>
-              <span class="secondary">Word on Fire Institute · currently enrolled</span>
+              <span class="secondary">Word on Fire Institute</span>
             </span>
-            <span class="year">In progress</span>
+            <span class="year">2026</span>
+          </li>
+          <li>
+            <span class="entry">
+              <span class="primary">Evangelism 101</span>
+              <span class="secondary">Word on Fire Institute</span>
+            </span>
+            <span class="year">2026</span>
           </li>
           <li>
             <span class="entry">

--- a/index.html
+++ b/index.html
@@ -39,13 +39,16 @@
         <span class="eyebrow">PhD Candidate · National University</span>
         <h1 id="home-title">Religious experience, thought, <span class="accent">&amp;</span> expression.</h1>
         <div class="cta-row">
-          <a class="btn" href="./projects.html">Explore the work</a>
-          <a class="arrow-link" href="./books.html">Browse publications</a>
+          <a class="btn" href="./projects.html">Projects</a>
+          <a class="arrow-link" href="./books.html">Books</a>
         </div>
-        <div class="tags" aria-label="Areas of focus">
-          <span>Media &amp; Religion</span>
-          <span>Cognitive Science of Religion</span>
-          <span>Dreams</span>
+        <div class="hero__areas">
+          <span class="meta meta--caps">Research Areas</span>
+          <div class="tags" aria-label="Areas of research">
+            <span>Media &amp; Religion</span>
+            <span>Cognitive Science of Religion</span>
+            <span>Dreams</span>
+          </div>
         </div>
       </div>
     </section>

--- a/style.css
+++ b/style.css
@@ -503,7 +503,12 @@ main { display: block; }
   font-weight: 380;
 }
 
-.hero .tags { margin-top: 2.6rem; }
+.hero__areas { margin-top: 2.6rem; }
+
+.hero__areas .meta--caps {
+  display: block;
+  margin-bottom: 0.7rem;
+}
 
 /* ---------- Featured publication ---------- */
 


### PR DESCRIPTION
## Summary
- Homepage hero: added a "Research Areas" caption above the Media & Religion / Cognitive Science of Religion / Dreams chips, so a first-time visitor understands what those tags represent
- Hero buttons renamed to match the pages they link to: "Explore the work" → "Projects", "Browse publications" → "Books"
- About page "Current roles": merged the Word on Fire Discussion Group Leader entry into the teaching role (renamed **Instructor** → **Educator**), dropped the certificate-specific wording in favor of a plain "discussion group leader at Word on Fire Institute" line
- Continuing education: marked "Advanced Evangelical Ethos of Bishop Barron" as completed (2026, was "in progress") and added the new "Evangelism 101" certificate (Word on Fire Institute, 2026)

## Test plan
- [x] Screenshotted the hero to confirm the new label and button text render cleanly
- [x] Screenshotted the About page's Current Roles and Continuing Education lists to confirm the merged Educator entry and the updated/new certification rows


---
_Generated by [Claude Code](https://claude.ai/code/session_01GUktHxoTAZPx2oYJAo93oC)_