### PR TITLE
Fix footer misalignment and add missing tagline links

### DIFF
--- a/about.html
+++ b/about.html
@@ -227,7 +227,9 @@
   <footer class="site-footer">
     <div class="wrap">
       <p class="name">Michael C. Barros</p>
-      <p class="tag">Research · Books · Projects</p>
+      <nav class="tag" aria-label="Explore">
+        <a href="./about.html#dissertation">Research</a> · <a href="./books.html">Books</a> · <a href="./projects.html">Projects</a>
+      </nav>
       <nav class="footer-links" aria-label="Profiles">
         <a href="https://orcid.org/0000-0001-5462-8926" target="_blank" rel="noopener">ORCID</a>
         <a href="https://national.academia.edu/MichaelBarros" target="_blank" rel="noopener">Academia.edu</a>

--- a/books.html
+++ b/books.html
@@ -116,7 +116,9 @@
   <footer class="site-footer">
     <div class="wrap">
       <p class="name">Michael C. Barros</p>
-      <p class="tag">Research · Books · Projects</p>
+      <nav class="tag" aria-label="Explore">
+        <a href="./about.html#dissertation">Research</a> · <a href="./books.html">Books</a> · <a href="./projects.html">Projects</a>
+      </nav>
       <nav class="footer-links" aria-label="Profiles">
         <a href="https://orcid.org/0000-0001-5462-8926" target="_blank" rel="noopener">ORCID</a>
         <a href="https://national.academia.edu/MichaelBarros" target="_blank" rel="noopener">Academia.edu</a>

--- a/contact.html
+++ b/contact.html
@@ -73,7 +73,9 @@
   <footer class="site-footer">
     <div class="wrap">
       <p class="name">Michael C. Barros</p>
-      <p class="tag">Research · Books · Projects</p>
+      <nav class="tag" aria-label="Explore">
+        <a href="./about.html#dissertation">Research</a> · <a href="./books.html">Books</a> · <a href="./projects.html">Projects</a>
+      </nav>
       <nav class="footer-links" aria-label="Profiles">
         <a href="https://orcid.org/0000-0001-5462-8926" target="_blank" rel="noopener">ORCID</a>
         <a href="https://national.academia.edu/MichaelBarros" target="_blank" rel="noopener">Academia.edu</a>

--- a/index.html
+++ b/index.html
@@ -188,7 +188,9 @@
   <footer class="site-footer">
     <div class="wrap">
       <p class="name">Michael C. Barros</p>
-      <p class="tag">Research · Books · Projects</p>
+      <nav class="tag" aria-label="Explore">
+        <a href="./about.html#dissertation">Research</a> · <a href="./books.html">Books</a> · <a href="./projects.html">Projects</a>
+      </nav>
       <nav class="footer-links" aria-label="Profiles">
         <a href="https://orcid.org/0000-0001-5462-8926" target="_blank" rel="noopener">ORCID</a>
         <a href="https://national.academia.edu/MichaelBarros" target="_blank" rel="noopener">Academia.edu</a>

--- a/projects.html
+++ b/projects.html
@@ -117,7 +117,9 @@
   <footer class="site-footer">
     <div class="wrap">
       <p class="name">Michael C. Barros</p>
-      <p class="tag">Research · Books · Projects</p>
+      <nav class="tag" aria-label="Explore">
+        <a href="./about.html#dissertation">Research</a> · <a href="./books.html">Books</a> · <a href="./projects.html">Projects</a>
+      </nav>
       <nav class="footer-links" aria-label="Profiles">
         <a href="https://orcid.org/0000-0001-5462-8926" target="_blank" rel="noopener">ORCID</a>
         <a href="https://national.academia.edu/MichaelBarros" target="_blank" rel="noopener">Academia.edu</a>

--- a/reading-list.html
+++ b/reading-list.html
@@ -1102,7 +1102,9 @@
   <footer class="site-footer">
     <div class="wrap">
       <p class="name">Michael C. Barros</p>
-      <p class="tag">Research · Books · Projects</p>
+      <nav class="tag" aria-label="Explore">
+        <a href="./about.html#dissertation">Research</a> · <a href="./books.html">Books</a> · <a href="./projects.html">Projects</a>
+      </nav>
       <nav class="footer-links" aria-label="Profiles">
         <a href="https://orcid.org/0000-0001-5462-8926" target="_blank" rel="noopener">ORCID</a>
         <a href="https://national.academia.edu/MichaelBarros" target="_blank" rel="noopener">Academia.edu</a>

--- a/style.css
+++ b/style.css
@@ -1180,6 +1180,7 @@ main { display: block; }
 }
 
 .site-footer .name {
+  max-width: none;
   font-family: var(--serif);
   font-size: 1.15rem;
   color: var(--ink);
@@ -1187,12 +1188,24 @@ main { display: block; }
 }
 
 .site-footer .tag {
+  max-width: none;
   font-size: 0.72rem;
   font-weight: 600;
   letter-spacing: 0.22em;
   text-transform: uppercase;
   color: var(--ink-faint);
   margin-bottom: 1.4rem;
+}
+
+.site-footer .tag a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.site-footer .tag a:hover {
+  color: var(--accent-deep);
+  text-decoration: underline;
+  text-underline-offset: 0.2em;
 }
 
 .footer-links {
@@ -1208,6 +1221,7 @@ main { display: block; }
 .footer-links a:hover { color: var(--accent-deep); }
 
 .site-footer .fine {
+  max-width: none;
   font-size: 0.78rem;
   color: var(--ink-faint);
   margin: 0;

--- a/timeline.html
+++ b/timeline.html
@@ -79,7 +79,9 @@
   <footer class="site-footer">
     <div class="wrap">
       <p class="name">Michael C. Barros</p>
-      <p class="tag">Research · Books · Projects</p>
+      <nav class="tag" aria-label="Explore">
+        <a href="./about.html#dissertation">Research</a> · <a href="./books.html">Books</a> · <a href="./projects.html">Projects</a>
+      </nav>
       <nav class="footer-links" aria-label="Profiles">
         <a href="https://orcid.org/0000-0001-5462-8926" target="_blank" rel="noopener">ORCID</a>
         <a href="https://national.academia.edu/MichaelBarros" target="_blank" rel="noopener">Academia.edu</a>


### PR DESCRIPTION
## Summary
- Root cause: the site-wide `p { max-width: 66ch }` readability rule was also constraining the footer's name/tagline/copyright `<p>` elements. Since none of them had `margin: auto`, that narrower box sat flush against the left edge instead of being centered — `text-align: center` only centered the text *within* that already-misplaced box, producing the lopsided desktop layout shown in the bug report screenshot.
- Fixed by adding `max-width: none` to `.site-footer .name`, `.tag`, and `.fine` so they span the full container width, letting `text-align: center` work correctly.
- Turned the "Research · Books · Projects" tagline into real links (Research → about.html#dissertation, Books → books.html, Projects → projects.html) — it was plain unlinked text while the ORCID/Academia.edu/LinkedIn row below it was already linked, which was inconsistent.

## Test plan
- [x] Reproduced the original misalignment locally at 1280px width, confirmed it matched the reported screenshot
- [x] Verified the footer is correctly centered at desktop (1280px), tablet (700px), and mobile (428px) widths after the fix
- [x] Verified all three tagline links resolve to the correct pages and the hover state renders correctly


---
_Generated by [Claude Code](https://claude.ai/code/session_01GUktHxoTAZPx2oYJAo93oC)_