### PR TITLE
Fix date misalignment on longer CV/About row-list titles

### DIFF
--- a/style.css
+++ b/style.css
@@ -721,7 +721,7 @@ main { display: block; }
   align-items: baseline;
   justify-content: space-between;
   gap: 0.5rem 2rem;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   padding: 1.1rem 1.3rem;
   background: var(--card);
   border: 1px solid var(--rule);
@@ -751,10 +751,18 @@ main { display: block; }
   font-weight: 400;
 }
 
+/* .row-list li is flex-wrap:nowrap so .year always stays pinned on the
+   same line as .entry; min-width:0 overrides .entry's default min-width:
+   auto so it can shrink and wrap its own text instead of forcing the row
+   to overflow (or, pre-nowrap, knocking .year onto its own line whenever
+   a title's natural one-line width left no room beside .year). */
+.row-list .entry { min-width: 0; }
+
 /* Force the date onto its own line below ~840px so short entries (e.g. a
    brief degree title) don't sit inline while longer siblings wrap — keeps
    every row's date in the same position regardless of content length. */
 @media (max-width: 840px) {
+  .row-list li { flex-wrap: wrap; }
   .row-list .entry { width: 100%; }
 }
 


### PR DESCRIPTION
## Bug
On the CV "Professional Development" list (and any other `.row-list`, e.g. About's Education), one entry's date dropped onto its own line, left-aligned, instead of staying pinned top-right like every sibling row — see the "Certificate in Evangelization: The Advanced Evangelical Ethos of Bishop Barron" row.

## Root cause
`.row-list li` used `flex-wrap: wrap`. With wrapping enabled, the browser decides whether the date fits on the same line using the title's **natural single-line width**, not its shrunk/wrapped width. A title just long enough to nearly fill the row — even while still fitting on one line — left no room beside the date, so the whole flex line wrapped and the date fell to a new line.

## Fix
- `.row-list li` → `flex-wrap: nowrap` on desktop, so the date always stays on the same line as the title.
- `.row-list .entry { min-width: 0; }` so the title can shrink and wrap its own text internally instead of overflowing.
- Re-enabled `flex-wrap: wrap` inside the existing sub-840px media query, where the date is meant to stack below the title on mobile.

## Test plan
- [x] CV → Professional Development: the "Advanced Evangelical Ethos" title now wraps to two lines with "2026" pinned top-right, matching every other row
- [x] About → Education: the PhD row (longest title on the page, two lines) still keeps "ABD — In progress" pinned top-right
- [x] Verified the mobile stacked layout (date below title) still works at 480px

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GUktHxoTAZPx2oYJAo93oC

---
_Generated by [Claude Code](https://claude.ai/code/session_01GUktHxoTAZPx2oYJAo93oC)_