### PR TITLE
Clean URLs — drop .html from all internal links

### DIFF
--- a/404.html
+++ b/404.html
@@ -25,7 +25,7 @@
         <p>The link may be broken or the page may have moved.</p>
         <div class="cta-row">
           <a class="btn" href="/">Back home</a>
-          <a class="arrow-link" href="/books.html">Browse books</a>
+          <a class="arrow-link" href="/books">Browse books</a>
         </div>
       </section>
     </div>

--- a/about.html
+++ b/about.html
@@ -6,12 +6,12 @@
   <title>About — Michael C. Barros</title>
   <meta name="description" content="Michael C. Barros — background, current work, education, and the path from military and technical work into psychology and religious studies." />
   <meta name="theme-color" content="#f5f7fb" />
-  <link rel="canonical" href="https://michaelcbarros.com/about.html" />
+  <link rel="canonical" href="https://michaelcbarros.com/about" />
   <meta property="og:type" content="profile" />
   <meta property="og:site_name" content="Michael C. Barros" />
   <meta property="og:title" content="About — Michael C. Barros" />
   <meta property="og:description" content="Michael C. Barros — background, current work, education, and the path from military and technical work into psychology and religious studies." />
-  <meta property="og:url" content="https://michaelcbarros.com/about.html" />
+  <meta property="og:url" content="https://michaelcbarros.com/about" />
   <meta property="og:image" content="https://michaelcbarros.com/assets/images/portrait.jpg" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="About — Michael C. Barros" />
@@ -138,7 +138,7 @@
         </div>
         <div class="reveal">
           <p>My doctoral research examines how supernatural agents and religious concepts are formed and represented in dreams. The project draws on grounded cognition, predictive processing, dream research, and the cognitive science of religion to investigate how sensory, emotional, social, and narrative information contributes to religious cognition during sleep.</p>
-          <p>For a fuller description of the dissertation and related work, see the <a href="/projects.html#dissertation">Research &amp; Projects page</a>.</p>
+          <p>For a fuller description of the dissertation and related work, see the <a href="/projects#dissertation">Research &amp; Projects page</a>.</p>
         </div>
       </div>
     </section>

--- a/books.html
+++ b/books.html
@@ -6,12 +6,12 @@
   <title>Books — Michael C. Barros</title>
   <meta name="description" content="Books by Michael C. Barros — The Esoteric Theology of Philip K. Dick, The Legend of Zelda &amp; Religion, and Philip K. Dick's Omega Point." />
   <meta name="theme-color" content="#f5f7fb" />
-  <link rel="canonical" href="https://michaelcbarros.com/books.html" />
+  <link rel="canonical" href="https://michaelcbarros.com/books" />
   <meta property="og:type" content="website" />
   <meta property="og:site_name" content="Michael C. Barros" />
   <meta property="og:title" content="Books — Michael C. Barros" />
   <meta property="og:description" content="Books by Michael C. Barros — The Esoteric Theology of Philip K. Dick, The Legend of Zelda &amp; Religion, and Philip K. Dick's Omega Point." />
-  <meta property="og:url" content="https://michaelcbarros.com/books.html" />
+  <meta property="og:url" content="https://michaelcbarros.com/books" />
   <meta property="og:image" content="https://michaelcbarros.com/assets/images/books/pkd.jpg" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Books — Michael C. Barros" />
@@ -30,17 +30,17 @@
         "author": [{ "@type": "Person", "name": "Michael C. Barros" }, { "@type": "Person", "name": "George J. Sieg" }],
         "publisher": { "@type": "Organization", "name": "Bloomsbury Academic" },
         "datePublished": "2026-01-08", "bookFormat": "https://schema.org/Hardcover",
-        "url": "https://michaelcbarros.com/books.html#pkd" } },
+        "url": "https://michaelcbarros.com/books#pkd" } },
       { "@type": "ListItem", "position": 2, "item": {
         "@type": "Book", "name": "The Legend of Zelda & Religion",
         "author": [{ "@type": "Person", "name": "Michael C. Barros" }, { "@type": "Person", "name": "Talbot Hook" }],
         "publisher": { "@type": "Organization", "name": "Bloomsbury Academic" },
-        "url": "https://michaelcbarros.com/books.html#zelda" } },
+        "url": "https://michaelcbarros.com/books#zelda" } },
       { "@type": "ListItem", "position": 3, "item": {
         "@type": "Book", "name": "Philip K. Dick's Omega Point",
         "author": { "@type": "Person", "name": "Michael C. Barros" },
         "publisher": { "@type": "Organization", "name": "Anti-Oedipus Press" },
-        "url": "https://michaelcbarros.com/books.html#omega-point" } }
+        "url": "https://michaelcbarros.com/books#omega-point" } }
     ]
   }
   </script>

--- a/contact.html
+++ b/contact.html
@@ -6,12 +6,12 @@
   <title>Contact — Michael C. Barros</title>
   <meta name="description" content="Contact Michael C. Barros for academic, research, editorial, media, speaking, or professional inquiries." />
   <meta name="theme-color" content="#f5f7fb" />
-  <link rel="canonical" href="https://michaelcbarros.com/contact.html" />
+  <link rel="canonical" href="https://michaelcbarros.com/contact" />
   <meta property="og:type" content="website" />
   <meta property="og:site_name" content="Michael C. Barros" />
   <meta property="og:title" content="Contact — Michael C. Barros" />
   <meta property="og:description" content="Contact Michael C. Barros for academic, research, editorial, media, speaking, or professional inquiries." />
-  <meta property="og:url" content="https://michaelcbarros.com/contact.html" />
+  <meta property="og:url" content="https://michaelcbarros.com/contact" />
   <meta property="og:image" content="https://michaelcbarros.com/assets/images/portrait.jpg" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Contact — Michael C. Barros" />

--- a/cv.html
+++ b/cv.html
@@ -6,12 +6,12 @@
   <title>Curriculum Vitae — Michael C. Barros</title>
   <meta name="description" content="My complete academic and professional record is available as a downloadable PDF." />
   <meta name="theme-color" content="#f5f7fb" />
-  <link rel="canonical" href="https://michaelcbarros.com/cv.html" />
+  <link rel="canonical" href="https://michaelcbarros.com/cv" />
   <meta property="og:type" content="website" />
   <meta property="og:site_name" content="Michael C. Barros" />
   <meta property="og:title" content="Curriculum Vitae — Michael C. Barros" />
   <meta property="og:description" content="My complete academic and professional record is available as a downloadable PDF." />
-  <meta property="og:url" content="https://michaelcbarros.com/cv.html" />
+  <meta property="og:url" content="https://michaelcbarros.com/cv" />
   <meta property="og:image" content="https://michaelcbarros.com/assets/images/portrait.jpg" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Curriculum Vitae — Michael C. Barros" />

--- a/index.html
+++ b/index.html
@@ -84,7 +84,7 @@
             <span class="eyebrow">Featured Book</span>
             <h2 id="featured-title" style="margin:0">The Esoteric Theology of Philip&nbsp;K.&nbsp;Dick</h2>
           </div>
-          <a class="more arrow-link" href="./books.html">All books</a>
+          <a class="more arrow-link" href="./books">All books</a>
         </div>
         <div class="pub-feature reveal">
           <a class="pub-feature__cover" href="https://amzn.to/46Fn12N" target="_blank" rel="noopener" aria-label="Order The Esoteric Theology of Philip K. Dick">
@@ -95,7 +95,7 @@
             <p style="margin-top:1rem">A collection marking the 50th anniversary of Philip K. Dick's 1974 mystical experiences, examining his self-understanding as Christian, gnostic, mystic, and theologian. Edited with G.&nbsp;Sieg.</p>
             <div class="cta-row">
               <a class="btn btn--small" href="https://amzn.to/46Fn12N" target="_blank" rel="noopener">Order the book</a>
-              <a class="arrow-link" href="./books.html">Details &amp; citation</a>
+              <a class="arrow-link" href="./books">Details &amp; citation</a>
             </div>
           </div>
         </div>
@@ -113,21 +113,21 @@
         </div>
         <ul class="index-list reveal">
           <li>
-            <a href="./about.html">
+            <a href="./about">
               <span class="t">About</span>
               <span class="d">Background, current work, education, and the path from military and technical work into psychology and religious studies.</span>
               <span class="arrow" aria-hidden="true">→</span>
             </a>
           </li>
           <li>
-            <a href="./projects.html">
+            <a href="./projects">
               <span class="t">Research &amp; Projects</span>
               <span class="d">Current research, educational initiatives, and collaborative work in the scientific study of religion and religious experience.</span>
               <span class="arrow" aria-hidden="true">→</span>
             </a>
           </li>
           <li>
-            <a href="./books.html">
+            <a href="./books">
               <span class="t">Books</span>
               <span class="d">Published and forthcoming books on Philip K. Dick, religion, theology, and popular culture.</span>
               <span class="arrow" aria-hidden="true">→</span>

--- a/js/data.js
+++ b/js/data.js
@@ -4,10 +4,10 @@ window.SITE_DATA = {
   // Primary navigation (order = display order). `key` matches <body data-page="…">.
   nav: [
     { href: '/', label: 'Home', key: 'home' },
-    { href: '/about.html', label: 'About', key: 'about' },
-    { href: '/projects.html', label: 'Research & Projects', key: 'projects' },
-    { href: '/books.html', label: 'Books', key: 'books' },
-    { href: '/contact.html', label: 'Contact', key: 'contact' },
+    { href: '/about', label: 'About', key: 'about' },
+    { href: '/projects', label: 'Research & Projects', key: 'projects' },
+    { href: '/books', label: 'Books', key: 'books' },
+    { href: '/contact', label: 'Contact', key: 'contact' },
   ],
 
   // External profile links (footer, About, Contact).
@@ -22,10 +22,10 @@ window.SITE_DATA = {
 
   // Footer page links, in display order, plus a direct CV download.
   footerNav: [
-    { href: '/about.html', label: 'About' },
-    { href: '/projects.html', label: 'Research & Projects' },
-    { href: '/books.html', label: 'Books' },
-    { href: '/contact.html', label: 'Contact' },
+    { href: '/about', label: 'About' },
+    { href: '/projects', label: 'Research & Projects' },
+    { href: '/books', label: 'Books' },
+    { href: '/contact', label: 'Contact' },
     { href: '/assets/Barros_CV_2026.pdf', label: 'Download CV', blank: true },
   ],
 
@@ -50,14 +50,14 @@ window.SITE_DATA = {
       brief: true,
       title: 'The Legend of Zelda &amp; Religion',
       desc: 'An edited volume under contract examining how religion and the sacred emerge from the structure and narrative of <em>The Legend of Zelda</em> series.',
-      bookUrl: '/books.html#zelda',
+      bookUrl: '/books#zelda',
     },
     {
       id: 'omega-point',
       brief: true,
       title: "Philip K. Dick's Omega Point",
       desc: "A monograph under contract examining the relationship between Philip K. Dick's religious thought and the theology of Pierre Teilhard de Chardin.",
-      bookUrl: '/books.html#omega-point',
+      bookUrl: '/books#omega-point',
     },
     {
       id: 'waypoint',

--- a/projects.html
+++ b/projects.html
@@ -6,12 +6,12 @@
   <title>Research &amp; Projects — Michael C. Barros</title>
   <meta name="description" content="Current research, educational initiatives, and collaborative work in the scientific study of religion and religious experience." />
   <meta name="theme-color" content="#f5f7fb" />
-  <link rel="canonical" href="https://michaelcbarros.com/projects.html" />
+  <link rel="canonical" href="https://michaelcbarros.com/projects" />
   <meta property="og:type" content="website" />
   <meta property="og:site_name" content="Michael C. Barros" />
   <meta property="og:title" content="Research &amp; Projects — Michael C. Barros" />
   <meta property="og:description" content="Current research, educational initiatives, and collaborative work in the scientific study of religion and religious experience." />
-  <meta property="og:url" content="https://michaelcbarros.com/projects.html" />
+  <meta property="og:url" content="https://michaelcbarros.com/projects" />
   <meta property="og:image" content="https://michaelcbarros.com/assets/images/portrait.jpg" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Research &amp; Projects — Michael C. Barros" />

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url><loc>https://michaelcbarros.com/</loc><lastmod>2026-07-17</lastmod><priority>1.0</priority></url>
-  <url><loc>https://michaelcbarros.com/about.html</loc><lastmod>2026-07-17</lastmod><priority>0.9</priority></url>
-  <url><loc>https://michaelcbarros.com/projects.html</loc><lastmod>2026-07-17</lastmod><priority>0.8</priority></url>
-  <url><loc>https://michaelcbarros.com/books.html</loc><lastmod>2026-07-17</lastmod><priority>0.8</priority></url>
-  <url><loc>https://michaelcbarros.com/contact.html</loc><lastmod>2026-07-17</lastmod><priority>0.6</priority></url>
-  <url><loc>https://michaelcbarros.com/cv.html</loc><lastmod>2026-07-17</lastmod><priority>0.3</priority></url>
+  <url><loc>https://michaelcbarros.com/about</loc><lastmod>2026-07-17</lastmod><priority>0.9</priority></url>
+  <url><loc>https://michaelcbarros.com/projects</loc><lastmod>2026-07-17</lastmod><priority>0.8</priority></url>
+  <url><loc>https://michaelcbarros.com/books</loc><lastmod>2026-07-17</lastmod><priority>0.8</priority></url>
+  <url><loc>https://michaelcbarros.com/contact</loc><lastmod>2026-07-17</lastmod><priority>0.6</priority></url>
+  <url><loc>https://michaelcbarros.com/cv</loc><lastmod>2026-07-17</lastmod><priority>0.3</priority></url>
 </urlset>

--- a/timeline.html
+++ b/timeline.html
@@ -7,12 +7,12 @@
   <meta name="description" content="The career timeline is now part of the About page." />
   <meta name="theme-color" content="#f5f7fb" />
   <meta name="robots" content="noindex" />
-  <meta http-equiv="refresh" content="0; url=/about.html#career-education" />
-  <link rel="canonical" href="https://michaelcbarros.com/about.html" />
+  <meta http-equiv="refresh" content="0; url=/about#career-education" />
+  <link rel="canonical" href="https://michaelcbarros.com/about" />
   <link rel="icon" type="image/png" sizes="32x32" href="./assets/favicon-32.png?v=20260717" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon.png?v=20260717" />
   <link rel="stylesheet" href="./style.css?v=20260717" />
-  <script>location.replace('/about.html#career-education');</script>
+  <script>location.replace('/about#career-education');</script>
 </head>
 <body data-page="">
   <a class="skip-link" href="#main">Skip to content</a>
@@ -26,7 +26,7 @@
         <h1>This page has moved.</h1>
         <p>The career timeline is now part of the About page, under Career and Education.</p>
         <div class="cta-row">
-          <a class="btn" href="/about.html#career-education">View the timeline on About</a>
+          <a class="btn" href="/about#career-education">View the timeline on About</a>
         </div>
       </section>
     </div>


### PR DESCRIPTION
Drops the `.html` extension from every internal link site-wide, so nav clicks and shared URLs read `michaelcbarros.com/about` instead of `michaelcbarros.com/about.html`.

## Why this is safe
GitHub Pages already resolves an extensionless request to the matching `.html` file automatically — no directory restructuring, no `_redirects` file, and no custom server config needed (confirmed via GitHub's own docs/community discussions). So this is purely a "stop asking for the extension" change:

- The actual files (`about.html`, `books.html`, `projects.html`, `contact.html`, `cv.html`) are untouched and still on disk — old bookmarks, search results, and backlinks pointing at the `.html` URL keep working exactly as before.
- `404.html` keeps its required filename (GitHub Pages needs that exact name to serve it as the custom error page).

## What changed
- **Nav & footer** (`js/data.js`): all hrefs now extensionless.
- **In-page links**: About's link to Research & Projects, the homepage's Explore cards, 404's "Browse books" link, Timeline's redirect target.
- **SEO surface**: `canonical` tags, `og:url`/Twitter URLs, the Books page's JSON-LD `ItemList` URLs (with anchors like `#pkd`/`#zelda` preserved), and `sitemap.xml` — all now point to the extensionless URL as the preferred/canonical form.

## Test plan
- [x] Every `.html` file still loads directly with zero console/network errors (Playwright sweep)
- [x] All nav and footer hrefs confirmed extensionless via DOM inspection
- [x] Anchor links (`/projects#dissertation`, `/about#career-education`, `/books#zelda`, etc.) preserved correctly through the substitution
- [x] `404.html` filename left untouched (only its internal link was updated)
- Note: my local dev server (Python's `http.server`) doesn't replicate GitHub Pages' extensionless resolution, so the actual `/about`-without-extension behavior can only be confirmed once this is live — recommend a quick click-through after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GUktHxoTAZPx2oYJAo93oC

---
_Generated by [Claude Code](https://claude.ai/code/session_01GUktHxoTAZPx2oYJAo93oC)_