### PR TITLE
Cut wordy prose from the recent restructure back to terse

### DIFF
--- a/about.html
+++ b/about.html
@@ -39,7 +39,6 @@
       color: var(--ink-faint);
       font-style: italic;
     }
-    .about-bio p + p { margin-top: 1.1rem; }
   </style>
   <script type="application/ld+json">
   {
@@ -78,12 +77,7 @@
           <div>
             <span class="eyebrow">About</span>
             <h1 id="about-title">Michael C. Barros</h1>
-            <div class="about-bio">
-              <p class="lede">I study religion and religious experience: how they are generated, how they are expressed, and what they mean for individuals and cultures.</p>
-              <p>My academic work brings together psychology, cognitive science, religious studies, and the humanities. My primary research concerns dreams, grounded cognition, supernatural-agent concepts, and the cognitive science of religion. I also write about religion and popular culture, particularly science fiction, literature, video games, media, ritual, and simulation.</p>
-              <p>My path into this work has not been conventional. Before entering religious studies and psychology, I worked in military satellite operations and completed degrees in electronics engineering technology and mathematics. I later earned a graduate degree in biblical and theological studies and began doctoral work in psychology. Alongside my academic work, I have taught philosophy and psychology, worked in publishing and editorial roles, conducted quantitative research, and managed business operations in the live-events industry.</p>
-              <p>That combination of fields shapes the questions I pursue. I am interested both in the mechanisms underlying religious thought and experience and in the ways religious ideas appear in stories, technologies, institutions, and popular culture.</p>
-            </div>
+            <p class="lede">I'm interested in religion and religious experience — how it's generated, how it's expressed, and what it means.</p>
           </div>
           <figure class="about-photo reveal" style="margin:0">
             <img src="./assets/images/portrait.jpg" alt="Michael C. Barros presenting a conference paper" width="1000" height="1250" loading="lazy" />
@@ -106,22 +100,22 @@
           <li>
             <p class="role">PhD Candidate, Psychology</p>
             <p class="org">National University</p>
-            <p class="desc">My doctoral research examines the formation of supernatural-agent concepts in dreams through grounded cognition, predictive processing, and the cognitive science of religion.</p>
+            <p class="desc">Researching how dreams shape supernatural and religious concepts.</p>
           </li>
           <li>
             <p class="role">Research Assistant</p>
             <p class="org">Harmony Academy at National University</p>
-            <p class="desc">I support the research team through quantitative analysis, data interpretation, and related research work in education.</p>
+            <p class="desc">Quantitative research and data analysis.</p>
           </li>
           <li>
             <p class="role">Adjunct Instructor</p>
             <p class="org">University of the People</p>
-            <p class="desc">I teach courses in philosophy and psychology, with an emphasis on clear reasoning, conceptual analysis, and the application of philosophical ideas.</p>
+            <p class="desc">Teaching philosophy and psychology courses.</p>
           </li>
           <li>
             <p class="role">Director of Business Affairs</p>
             <p class="org">OYD Live</p>
-            <p class="desc">I oversee contracting, business operations, event coordination, and process improvement for a live-events management and promotion company.</p>
+            <p class="desc">Business operations and event coordination.</p>
           </li>
         </ul>
       </div>
@@ -137,8 +131,7 @@
           </div>
         </div>
         <div class="reveal">
-          <p>My doctoral research examines how supernatural agents and religious concepts are formed and represented in dreams. The project draws on grounded cognition, predictive processing, dream research, and the cognitive science of religion to investigate how sensory, emotional, social, and narrative information contributes to religious cognition during sleep.</p>
-          <p>For a fuller description of the dissertation and related work, see the <a href="/projects#dissertation">Research &amp; Projects page</a>.</p>
+          <p>How dreams shape supernatural and religious concepts. <a href="/projects#dissertation">More on the Research &amp; Projects page →</a></p>
         </div>
       </div>
     </section>
@@ -152,7 +145,7 @@
             <h2 id="career-title" style="margin:0">Career and Education</h2>
           </div>
         </div>
-        <p class="reveal" style="margin-bottom:2rem">My career developed across several fields that are not immediately obvious from a conventional résumé. This timeline shows the progression from military and technical work into teaching, publishing, religious studies, psychology, research, and business operations. Several of these areas have continued to overlap rather than replacing one another.</p>
+        <p class="reveal" style="margin-bottom:2rem">Concurrent tracks across scholarship, teaching, research, publishing, and operations. Select any bar for details.</p>
 
         <div class="tl-legend" aria-hidden="true">
           <span><i class="tl-dot tl-dot--professional"></i>Professional</span>
@@ -252,7 +245,7 @@
           </div>
         </div>
         <div class="reveal">
-          <p>A complete record of my publications, presentations, teaching, research, professional experience, service, certifications, and awards is available in my academic CV.</p>
+          <p>My complete academic and professional record.</p>
           <div class="cta-row" style="margin-top:1.3rem">
             <a class="btn" href="/assets/Barros_CV_2026.pdf" target="_blank" rel="noopener">Download Full CV — PDF</a>
           </div>

--- a/index.html
+++ b/index.html
@@ -63,8 +63,6 @@
       <div class="wrap">
         <span class="eyebrow">PhD Candidate · National University</span>
         <h1 id="home-title">Michael C. Barros</h1>
-        <p class="lede">Michael C. Barros is a scholar of religion, psychology, and culture whose work examines religious experience, dreams, cognition, literature, and popular media.</p>
-        <p>His academic research focuses on the cognitive science of religion and the formation of supernatural concepts in dreams. His broader writing explores religion and culture through subjects including Philip K. Dick, The Legend of Zelda, science fiction, media, ritual, and simulation.</p>
         <div class="hero__areas">
           <span class="meta meta--caps">Research Areas</span>
           <div class="tags" aria-label="Areas of research">

--- a/js/data.js
+++ b/js/data.js
@@ -38,10 +38,7 @@ window.SITE_DATA = {
       title: 'Supernatural-Agent Concepts in Dreams',
       org: 'National University · Chair: Dr. Patrick McNamara',
       status: 'Active',
-      desc:
-        '<p>My doctoral research examines how supernatural agents and religious concepts are formed and represented during dreams. The project brings together grounded cognition, predictive processing, dream research, and the cognitive science of religion.</p>' +
-        '<p>Using longitudinal dream reports, psychological measures, and sleep data, the study investigates how sensory, emotional, social, and narrative features contribute to changes in religious and supernatural thought across sleep and waking experience.</p>' +
-        '<p>The broader goal is to develop an empirically grounded account of how religious concepts emerge from embodied and simulated experience rather than treating them solely as abstract beliefs.</p>',
+      desc: '<p>Doctoral research on how supernatural agents and religious concepts form and appear in dreams, drawing on grounded cognition, predictive processing, and the cognitive science of religion.</p>',
       current: 'data analysis &amp; chapter drafting',
       tags: ['Grounded Cognition', 'Dreams', 'Supernatural Agents', 'Religiosity'],
     },
@@ -65,7 +62,7 @@ window.SITE_DATA = {
       title: 'Waypoint Institute',
       org: 'waypoint.institute · Operations Director',
       status: 'Active',
-      desc: '<p>Waypoint Institute is a developing Christian educational initiative intended to provide serious theological and humanities education without tuition barriers. Its long-term aim is to make structured Christian learning available to students who may not have access to conventional academic institutions.</p>',
+      desc: '<p>A developing tuition-free Christian education initiative in theology and the humanities.</p>',
       url: 'https://waypoint.institute',
     },
     {
@@ -74,7 +71,7 @@ window.SITE_DATA = {
       title: 'Religious Cognition Collaborative',
       org: 'religiouscognitioncollab.org · Managing Director',
       status: 'Active',
-      desc: '<p>The Religious Cognition Collaborative supports interdisciplinary research on religion, cognition, neuroscience, psychology, and religious experience. Its work is intended to connect researchers across fields, encourage collaborative projects, and make research on religious cognition more accessible beyond narrow disciplinary boundaries.</p>',
+      desc: '<p>A research network connecting scholars studying religion, cognition, and religious experience.</p>',
       url: 'https://www.religiouscognitioncollab.org',
     },
   ],


### PR DESCRIPTION
The About/Home/Research & Projects rewrite added several multi-sentence prose paragraphs that read as bloat. Cuts all of it back down to the site's original terse tone.

## What changed
- **Homepage hero**: dropped both intro paragraphs entirely — back to just the headline and research-area tags (matches the page's original zero-paragraph hero).
- **About bio**: reverted to the single original lede line ("I'm interested in religion and religious experience — how it's generated, how it's expressed, and what it means."), replacing the 4-paragraph biography. Removed the now-unused `.about-bio` CSS.
- **About Current Work**: all four cards down to one short clause each instead of full sentences.
- **About Research Focus**: one sentence + a link out to Research & Projects, instead of two paragraphs.
- **About Career and Education**: intro paragraph replaced with the old Timeline page's short lede ("Concurrent tracks across scholarship, teaching, research, publishing, and operations. Select any bar for details.").
- **About Full CV section**: one short line instead of a sentence enumerating every CV section.
- **Research & Projects** (`js/data.js`): dissertation description down from three paragraphs to one; Waypoint Institute and Religious Cognition Collaborative down to one sentence each.

## Test plan
- [x] Playwright sweep of every page — zero console/network errors
- [x] Verified visually on mobile viewport (430px) against the pages the wordiness was flagged on
- [x] Confirmed no orphaned CSS (`.about-bio`) or stale references left behind
- [x] Swept remaining `<p>` content site-wide for outliers — the two paragraphs over 15 words left are legitimate (the featured-book blurb, and the restored original About lede)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GUktHxoTAZPx2oYJAo93oC

---
_Generated by [Claude Code](https://claude.ai/code/session_01GUktHxoTAZPx2oYJAo93oC)_