### PR TITLE
Remove redundant lede from Initiatives page

### DIFF
--- a/initiatives.html
+++ b/initiatives.html
@@ -32,7 +32,6 @@
       <div class="wrap">
         <span class="eyebrow">Overview</span>
         <h1 id="initiatives-title">Initiatives</h1>
-        <p class="lede">Waypoint Institute and the Religious Cognition Collaborative.</p>
       </div>
     </section>
 


### PR DESCRIPTION
The Initiatives page-head had a `<p class="lede">Waypoint Institute and the Religious Cognition Collaborative.</p>` line that just named the two cards shown immediately below it. Removed it.

The noscript fallback (which serves the same names to no-JS visitors, since the cards themselves are JS-rendered) is left as-is — it's not redundant there, since without JS nothing else on the page names them.

## Test plan
- [x] Verified visually — heading now sits directly above the card list with no leftover gap
- [x] Zero console/network errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GUktHxoTAZPx2oYJAo93oC

---
_Generated by [Claude Code](https://claude.ai/code/session_01GUktHxoTAZPx2oYJAo93oC)_