### PR TITLE
Hide Religious Cognition Collaborative; new site-wide title template

### DIFF
--- a/404.html
+++ b/404.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Page not found — Michael C. Barros</title>
+  <title>Page not found | Michael C. Barros</title>
   <meta name="description" content="The page you were looking for could not be found." />
   <meta name="theme-color" content="#f5f7fb" />
   <meta name="robots" content="noindex" />

--- a/about.html
+++ b/about.html
@@ -3,18 +3,18 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>About — Michael C. Barros</title>
+  <title>About | Michael C. Barros</title>
   <meta name="description" content="Michael C. Barros — background, current work, education, and the path from military and technical work into psychology and religious studies." />
   <meta name="theme-color" content="#f5f7fb" />
   <link rel="canonical" href="https://michaelcbarros.com/about" />
   <meta property="og:type" content="profile" />
   <meta property="og:site_name" content="Michael C. Barros" />
-  <meta property="og:title" content="About — Michael C. Barros" />
+  <meta property="og:title" content="About | Michael C. Barros" />
   <meta property="og:description" content="Michael C. Barros — background, current work, education, and the path from military and technical work into psychology and religious studies." />
   <meta property="og:url" content="https://michaelcbarros.com/about" />
   <meta property="og:image" content="https://michaelcbarros.com/assets/images/portrait.jpg" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="About — Michael C. Barros" />
+  <meta name="twitter:title" content="About | Michael C. Barros" />
   <meta name="twitter:description" content="Michael C. Barros — background, current work, education, and the path from military and technical work into psychology and religious studies." />
   <meta name="twitter:image" content="https://michaelcbarros.com/assets/images/portrait.jpg" />
   <link rel="icon" type="image/png" sizes="32x32" href="./assets/favicon-32.png?v=20260717" />

--- a/books.html
+++ b/books.html
@@ -3,18 +3,18 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Books — Michael C. Barros</title>
+  <title>Books | Michael C. Barros</title>
   <meta name="description" content="Books by Michael C. Barros — The Esoteric Theology of Philip K. Dick, The Legend of Zelda &amp; Religion, and Philip K. Dick's Omega Point." />
   <meta name="theme-color" content="#f5f7fb" />
   <link rel="canonical" href="https://michaelcbarros.com/books" />
   <meta property="og:type" content="website" />
   <meta property="og:site_name" content="Michael C. Barros" />
-  <meta property="og:title" content="Books — Michael C. Barros" />
+  <meta property="og:title" content="Books | Michael C. Barros" />
   <meta property="og:description" content="Books by Michael C. Barros — The Esoteric Theology of Philip K. Dick, The Legend of Zelda &amp; Religion, and Philip K. Dick's Omega Point." />
   <meta property="og:url" content="https://michaelcbarros.com/books" />
   <meta property="og:image" content="https://michaelcbarros.com/assets/images/books/pkd.jpg" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Books — Michael C. Barros" />
+  <meta name="twitter:title" content="Books | Michael C. Barros" />
   <meta name="twitter:description" content="Books by Michael C. Barros — The Esoteric Theology of Philip K. Dick, The Legend of Zelda &amp; Religion, and Philip K. Dick's Omega Point." />
   <meta name="twitter:image" content="https://michaelcbarros.com/assets/images/books/pkd.jpg" />
   <link rel="icon" type="image/png" sizes="32x32" href="./assets/favicon-32.png?v=20260717" />

--- a/contact.html
+++ b/contact.html
@@ -3,18 +3,18 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Contact — Michael C. Barros</title>
+  <title>Contact | Michael C. Barros</title>
   <meta name="description" content="Contact Michael C. Barros for academic, research, editorial, media, speaking, or professional inquiries." />
   <meta name="theme-color" content="#f5f7fb" />
   <link rel="canonical" href="https://michaelcbarros.com/contact" />
   <meta property="og:type" content="website" />
   <meta property="og:site_name" content="Michael C. Barros" />
-  <meta property="og:title" content="Contact — Michael C. Barros" />
+  <meta property="og:title" content="Contact | Michael C. Barros" />
   <meta property="og:description" content="Contact Michael C. Barros for academic, research, editorial, media, speaking, or professional inquiries." />
   <meta property="og:url" content="https://michaelcbarros.com/contact" />
   <meta property="og:image" content="https://michaelcbarros.com/assets/images/portrait.jpg" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Contact — Michael C. Barros" />
+  <meta name="twitter:title" content="Contact | Michael C. Barros" />
   <meta name="twitter:description" content="Contact Michael C. Barros for academic, research, editorial, media, speaking, or professional inquiries." />
   <meta name="twitter:image" content="https://michaelcbarros.com/assets/images/portrait.jpg" />
   <link rel="icon" type="image/png" sizes="32x32" href="./assets/favicon-32.png?v=20260717" />

--- a/cv.html
+++ b/cv.html
@@ -3,18 +3,18 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Curriculum Vitae — Michael C. Barros</title>
+  <title>Curriculum Vitae | Michael C. Barros</title>
   <meta name="description" content="My complete academic and professional record is available as a downloadable PDF." />
   <meta name="theme-color" content="#f5f7fb" />
   <link rel="canonical" href="https://michaelcbarros.com/cv" />
   <meta property="og:type" content="website" />
   <meta property="og:site_name" content="Michael C. Barros" />
-  <meta property="og:title" content="Curriculum Vitae — Michael C. Barros" />
+  <meta property="og:title" content="Curriculum Vitae | Michael C. Barros" />
   <meta property="og:description" content="My complete academic and professional record is available as a downloadable PDF." />
   <meta property="og:url" content="https://michaelcbarros.com/cv" />
   <meta property="og:image" content="https://michaelcbarros.com/assets/images/portrait.jpg" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Curriculum Vitae — Michael C. Barros" />
+  <meta name="twitter:title" content="Curriculum Vitae | Michael C. Barros" />
   <meta name="twitter:description" content="My complete academic and professional record is available as a downloadable PDF." />
   <meta name="twitter:image" content="https://michaelcbarros.com/assets/images/portrait.jpg" />
   <link rel="icon" type="image/png" sizes="32x32" href="./assets/favicon-32.png?v=20260717" />

--- a/index.html
+++ b/index.html
@@ -3,18 +3,18 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Michael C. Barros — Religion, Psychology &amp; Culture</title>
+  <title>Michael C. Barros</title>
   <meta name="description" content="Michael C. Barros is a scholar of religion, psychology, and culture whose work examines religious experience, dreams, cognition, literature, and popular media." />
   <meta name="theme-color" content="#f5f7fb" />
   <link rel="canonical" href="https://michaelcbarros.com/" />
   <meta property="og:type" content="website" />
   <meta property="og:site_name" content="Michael C. Barros" />
-  <meta property="og:title" content="Michael C. Barros — Religion, Psychology &amp; Culture" />
+  <meta property="og:title" content="Michael C. Barros" />
   <meta property="og:description" content="Michael C. Barros is a scholar of religion, psychology, and culture whose work examines religious experience, dreams, cognition, literature, and popular media." />
   <meta property="og:url" content="https://michaelcbarros.com/" />
   <meta property="og:image" content="https://michaelcbarros.com/assets/images/portrait.jpg" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Michael C. Barros — Religion, Psychology &amp; Culture" />
+  <meta name="twitter:title" content="Michael C. Barros" />
   <meta name="twitter:description" content="Michael C. Barros is a scholar of religion, psychology, and culture whose work examines religious experience, dreams, cognition, literature, and popular media." />
   <meta name="twitter:image" content="https://michaelcbarros.com/assets/images/portrait.jpg" />
   <link rel="icon" type="image/png" sizes="32x32" href="./assets/favicon-32.png?v=20260717" />
@@ -126,7 +126,7 @@
           <li>
             <a href="./initiatives">
               <span class="t">Initiatives</span>
-              <span class="d">Waypoint Institute and the Religious Cognition Collaborative.</span>
+              <span class="d">Waypoint Institute.</span>
               <span class="arrow" aria-hidden="true">→</span>
             </a>
           </li>

--- a/initiatives.html
+++ b/initiatives.html
@@ -3,19 +3,19 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Initiatives — Michael C. Barros</title>
-  <meta name="description" content="Waypoint Institute and the Religious Cognition Collaborative." />
+  <title>Initiatives | Michael C. Barros</title>
+  <meta name="description" content="Waypoint Institute." />
   <meta name="theme-color" content="#f5f7fb" />
   <link rel="canonical" href="https://michaelcbarros.com/initiatives" />
   <meta property="og:type" content="website" />
   <meta property="og:site_name" content="Michael C. Barros" />
-  <meta property="og:title" content="Initiatives — Michael C. Barros" />
-  <meta property="og:description" content="Waypoint Institute and the Religious Cognition Collaborative." />
+  <meta property="og:title" content="Initiatives | Michael C. Barros" />
+  <meta property="og:description" content="Waypoint Institute." />
   <meta property="og:url" content="https://michaelcbarros.com/initiatives" />
   <meta property="og:image" content="https://michaelcbarros.com/assets/images/portrait.jpg" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Initiatives — Michael C. Barros" />
-  <meta name="twitter:description" content="Waypoint Institute and the Religious Cognition Collaborative." />
+  <meta name="twitter:title" content="Initiatives | Michael C. Barros" />
+  <meta name="twitter:description" content="Waypoint Institute." />
   <meta name="twitter:image" content="https://michaelcbarros.com/assets/images/portrait.jpg" />
   <link rel="icon" type="image/png" sizes="32x32" href="./assets/favicon-32.png?v=20260717" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon.png?v=20260717" />
@@ -40,7 +40,7 @@
         <div data-initiatives></div>
         <noscript>
           <div class="project" style="border-top:1px solid var(--rule)">
-            <p class="desc">Waypoint Institute and the Religious Cognition Collaborative. Enable JavaScript to view the full cards.</p>
+            <p class="desc">Waypoint Institute. Enable JavaScript to view the full cards.</p>
           </div>
         </noscript>
       </div>

--- a/js/data.js
+++ b/js/data.js
@@ -50,13 +50,5 @@ window.SITE_DATA = {
       desc: '<p>A developing tuition-free Christian education initiative in theology and the humanities.</p>',
       url: 'https://waypoint.institute',
     },
-    {
-      id: 'religious-cognition-collab',
-      title: 'Religious Cognition Collaborative',
-      org: 'religiouscognitioncollab.org · Managing Director',
-      status: 'Active',
-      desc: '<p>A research network connecting scholars studying religion, cognition, and religious experience.</p>',
-      url: 'https://www.religiouscognitioncollab.org',
-    },
   ],
 };

--- a/projects.html
+++ b/projects.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Projects moved — Michael C. Barros</title>
+  <title>Projects moved | Michael C. Barros</title>
   <meta name="description" content="This page is now Initiatives." />
   <meta name="theme-color" content="#f5f7fb" />
   <meta name="robots" content="noindex" />

--- a/timeline.html
+++ b/timeline.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Timeline moved — Michael C. Barros</title>
+  <title>Timeline moved | Michael C. Barros</title>
   <meta name="description" content="The career timeline is now part of the About page." />
   <meta name="theme-color" content="#f5f7fb" />
   <meta name="robots" content="noindex" />


### PR DESCRIPTION
Two independent changes.

## Hide the Religious Cognition Collaborative
- Removed its entry from `SITE_DATA.initiatives`, so it no longer renders as a card on the Initiatives page.
- Stripped every text mention of it: `initiatives.html`'s meta description, OG/Twitter descriptions, and noscript fallback, plus the homepage's Explore card description. Initiatives now shows only Waypoint Institute.
- Swept the whole repo for "Religious Cognition," "religiouscognitioncollab," and "RCC" — nothing remains.

## New title template
- Homepage `<title>`/`og:title`/`twitter:title` now read exactly **"Michael C. Barros"** — dropped the "Religion, Psychology & Culture" subtitle everywhere it appeared (browser tab and link-preview metadata).
- Every interior page's separator switched from an em dash to a pipe: **"[Page Name] | Michael C. Barros"** (About, Books, Contact, Curriculum Vitae, Initiatives), applied consistently across `<title>`, `og:title`, and `twitter:title`.
- Also normalized the two noindexed redirect stubs (old `/projects.html` and `/timeline.html`) to the same separator for consistency, though they don't carry OG tags since they're not indexed.

## Test plan
- [x] Swept for `Religion, Psychology` and the em-dash separator pattern site-wide — zero remaining
- [x] Confirmed every `<title>`, `og:title`, and `twitter:title` reads correctly per page
- [x] Playwright sweep of all 9 pages — zero console/network errors
- [x] Verified visually: Initiatives page shows only Waypoint Institute; homepage `document.title` is exactly "Michael C. Barros"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GUktHxoTAZPx2oYJAo93oC

---
_Generated by [Claude Code](https://claude.ai/code/session_01GUktHxoTAZPx2oYJAo93oC)_