### PR TITLE
Restyle homepage hero motto as a literary epigraph

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
   <meta name="twitter:image" content="https://michaelcbarros.com/assets/images/portrait.jpg" />
   <link rel="icon" type="image/png" sizes="32x32" href="./assets/favicon-32.png?v=20260717" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon.png?v=20260717" />
-  <link rel="stylesheet" href="./style.css?v=20260717" />
+  <link rel="stylesheet" href="./style.css?v=20260729" />
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -57,7 +57,7 @@
   <main id="main">
     <section class="hero" aria-labelledby="home-title">
       <div class="wrap">
-        <span class="eyebrow" style="color:var(--accent);font-style:italic">DISCERNING THE TRANSMUNDANE</span>
+        <span class="hero__motto">Discerning the Transmundane</span>
         <h1 id="home-title">Michael C. Barros</h1>
         <div class="hero__areas">
           <span class="meta meta--caps">Research Areas</span>

--- a/style.css
+++ b/style.css
@@ -514,6 +514,30 @@ main { display: block; }
   font-weight: 380;
 }
 
+/* A literary motto, not a section label — deliberately not .eyebrow. */
+.hero__motto {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  color: var(--accent);
+  font-family: var(--serif);
+  font-size: clamp(1.15rem, 2vw, 1.35rem);
+  font-style: italic;
+  font-weight: 380;
+  letter-spacing: 0.01em;
+  line-height: 1.2;
+  text-transform: none;
+  margin-bottom: 1.1rem;
+}
+
+.hero__motto::before {
+  content: '';
+  width: 2rem;
+  height: 2px;
+  flex: 0 0 auto;
+  background: currentColor;
+}
+
 .hero__areas { margin-top: 2.6rem; }
 
 .hero__areas .meta--caps {


### PR DESCRIPTION
Replaces the sans-serif, all-caps "eyebrow" treatment of "DISCERNING THE TRANSMUNDANE" with a dedicated `.hero__motto` class, so it reads as a literary epigraph rather than a section label.

## What changed
- Text: `DISCERNING THE TRANSMUNDANE` → `Discerning the Transmundane` (Title Case).
- Font: Fraunces serif italic (the site's display font) instead of the sans-serif eyebrow font.
- Weight: 380 — matches the existing accent-ampersand treatment already used elsewhere in this same hero (`.hero h1 .accent`), so it's proven to render cleanly on this font load rather than guessing at a value.
- Removed `text-transform: uppercase`; letter-spacing reduced to near-normal (`0.01em`).
- Kept the gold accent color and the small gold horizontal rule, vertically centered with the text.
- New `.hero__motto` class (not a reuse of `.eyebrow`), so every other eyebrow site-wide is untouched.
- Preserved the hero's vertical rhythm (`margin-bottom: 1.1rem`, matching what `.eyebrow` provided before).

## Test plan
- [x] Computed styles verified via Playwright: `font-family` Fraunces, `font-style` italic, `font-weight` 380, `text-transform` none, `letter-spacing` ~0.01em, color the gold accent
- [x] Verified visually — reads as an understated epigraph, not a label; rest of hero spacing unchanged
- [x] Zero console/network errors

Note: this branch's PR history got tangled by some out-of-band direct commits to `main` from outside this session (RCC removal + title-format work that had already shipped in an earlier PR from here). I rebased this change cleanly onto the current `main` tip, so this diff is just the motto restyle — nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GUktHxoTAZPx2oYJAo93oC

---
_Generated by [Claude Code](https://claude.ai/code/session_01GUktHxoTAZPx2oYJAo93oC)_